### PR TITLE
Add initial approve and unapprove APIs

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -42,5 +42,18 @@
 	"ResourceModules": {
 	},
 
+	"RestRoutes": [
+		{
+			"path": "/page-approvals/v0/page/{pageId}/approve",
+			"method": [ "POST" ],
+			"factory": "ProfessionalWiki\\PageApprovals\\PageApprovals::newApprovePageApi"
+		},
+		{
+			"path": "/page-approvals/v0/page/{pageId}/unapprove",
+			"method": [ "POST" ],
+			"factory": "ProfessionalWiki\\PageApprovals\\PageApprovals::newUnapprovePageApi"
+		}
+	],
+
 	"manifest_version": 2
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+  <file src="src/EntryPoints/REST/ApprovePageApi.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[run]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/EntryPoints/REST/UnapprovePageApi.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[run]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="src/PageApprovals.php">
-    <UnusedClass>
-      <code><![CDATA[PageApprovals]]></code>
-    </UnusedClass>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[getInstance]]></code>
+      <code><![CDATA[newApprovePageApi]]></code>
+      <code><![CDATA[newUnapprovePageApi]]></code>
+    </PossiblyUnusedMethod>
   </file>
 </files>

--- a/src/EntryPoints/REST/ApprovePageApi.php
+++ b/src/EntryPoints/REST/ApprovePageApi.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\EntryPoints\REST;
+
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use MediaWiki\Rest\StringStream;
+use Wikimedia\ParamValidator\ParamValidator;
+
+class ApprovePageApi extends SimpleHandler {
+
+	public function run( int $pageId ): Response {
+		// TODO: logic
+		$response = $this->getResponseFactory()->create();
+		$response->setStatus( 200 );
+		$response->setBody( new StringStream( "{ pageId: ${pageId} }" ) );
+		return $response;
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getParamSettings(): array {
+		return [
+			'pageId' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'integer',
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+		];
+	}
+
+}

--- a/src/EntryPoints/REST/UnapprovePageApi.php
+++ b/src/EntryPoints/REST/UnapprovePageApi.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\EntryPoints\REST;
+
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use MediaWiki\Rest\StringStream;
+use Wikimedia\ParamValidator\ParamValidator;
+
+class UnapprovePageApi extends SimpleHandler {
+
+	public function run( int $pageId ): Response {
+		// TODO: logic
+		$response = $this->getResponseFactory()->create();
+		$response->setStatus( 200 );
+		$response->setBody( new StringStream( "{ pageId: ${pageId} }" ) );
+		return $response;
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getParamSettings(): array {
+		return [
+			'pageId' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'integer',
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+		];
+	}
+
+}

--- a/src/PageApprovals.php
+++ b/src/PageApprovals.php
@@ -6,8 +6,11 @@ namespace ProfessionalWiki\PageApprovals;
 
 class PageApprovals {
 
-	public static function todo(): bool {
-		return true;
+	public static function getInstance(): self {
+		/** @var ?PageApprovals $instance */
+		static $instance = null;
+		$instance ??= new self();
+		return $instance;
 	}
 
 }

--- a/src/PageApprovals.php
+++ b/src/PageApprovals.php
@@ -4,6 +4,9 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\PageApprovals;
 
+use ProfessionalWiki\PageApprovals\EntryPoints\REST\ApprovePageApi;
+use ProfessionalWiki\PageApprovals\EntryPoints\REST\UnapprovePageApi;
+
 class PageApprovals {
 
 	public static function getInstance(): self {
@@ -11,6 +14,14 @@ class PageApprovals {
 		static $instance = null;
 		$instance ??= new self();
 		return $instance;
+	}
+
+	public static function newApprovePageApi(): ApprovePageApi {
+		return new ApprovePageApi();
+	}
+
+	public static function newUnapprovePageApi(): UnapprovePageApi {
+		return new UnapprovePageApi();
 	}
 
 }

--- a/tests/PageApprovalsIntegrationTest.php
+++ b/tests/PageApprovalsIntegrationTest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ProfessionalWiki\PageApprovals\Tests;
+
+class PageApprovalsIntegrationTest extends \MediaWikiIntegrationTestCase {
+
+}

--- a/tests/integration/EntryPoints/REST/ApprovePageApiTest.php
+++ b/tests/integration/EntryPoints/REST/ApprovePageApiTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ProfessionalWiki\PageApprovals\Tests\EntryPoints\REST;
+
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use ProfessionalWiki\PageApprovals\EntryPoints\REST\ApprovePageApi;
+use ProfessionalWiki\PageApprovals\Tests\PageApprovalsIntegrationTest;
+
+/**
+ * @covers \ProfessionalWiki\PageApprovals\EntryPoints\REST\ApprovePageApi
+ * @group database
+ */
+class ApprovePageApiTest extends PageApprovalsIntegrationTest {
+	use HandlerTestTrait;
+	use MockAuthorityTrait;
+
+	public function testApprovePageHappyPath(): void {
+		$response = $this->executeHandler(
+			$this->newApprovePageApi(),
+			$this->createValidRequestData( 1 )
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( '{ pageId: 1 }', $response->getBody()->getContents() );
+	}
+
+	private function newApprovePageApi(): ApprovePageApi {
+		return new ApprovePageApi();
+	}
+
+	private function createValidRequestData( int $pageId ): RequestData {
+		return new RequestData( [
+			'method' => 'POST',
+			'pathParams' => [
+				'pageId' => $pageId
+			],
+			'headers' => [
+				'Content-Type' => 'application/json'
+			]
+		] );
+	}
+
+}

--- a/tests/integration/EntryPoints/REST/UnapprovePageApiTest.php
+++ b/tests/integration/EntryPoints/REST/UnapprovePageApiTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ProfessionalWiki\PageApprovals\Tests\EntryPoints\REST;
+
+use MediaWiki\Rest\RequestData;
+use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use MediaWiki\Tests\Unit\Permissions\MockAuthorityTrait;
+use ProfessionalWiki\PageApprovals\EntryPoints\REST\UnapprovePageApi;
+use ProfessionalWiki\PageApprovals\Tests\PageApprovalsIntegrationTest;
+
+/**
+ * @covers \ProfessionalWiki\PageApprovals\EntryPoints\REST\UnapprovePageApi
+ * @group database
+ */
+class UnapprovePageApiTest extends PageApprovalsIntegrationTest {
+	use HandlerTestTrait;
+	use MockAuthorityTrait;
+
+	public function testUnapprovePageHappyPath(): void {
+		$response = $this->executeHandler(
+			$this->newUnapprovePageApi(),
+			$this->createValidRequestData( 1 )
+		);
+
+		$this->assertSame( 200, $response->getStatusCode() );
+		$this->assertSame( '{ pageId: 1 }', $response->getBody()->getContents() );
+	}
+
+	private function newUnapprovePageApi(): UnapprovePageApi {
+		return new UnapprovePageApi();
+	}
+
+	private function createValidRequestData( int $pageId ): RequestData {
+		return new RequestData( [
+			'method' => 'POST',
+			'pathParams' => [
+				'pageId' => $pageId
+			],
+			'headers' => [
+				'Content-Type' => 'application/json'
+			]
+		] );
+	}
+
+}

--- a/tests/unit/PageApprovalsTest.php
+++ b/tests/unit/PageApprovalsTest.php
@@ -8,8 +8,17 @@ use PHPUnit\Framework\TestCase;
 
 class PageApprovalsTest extends TestCase {
 
-	public function testTests(): void {
-		$this->assertTrue( PageApprovals::todo() );
+	public function testGetInstanceReturnsNewInstance(): void {
+		$instance = PageApprovals::getInstance();
+
+		$this->assertInstanceOf( PageApprovals::class, $instance );
+	}
+
+	public function testGetInstanceReturnsExistingInstance(): void {
+		$instance1 = PageApprovals::getInstance();
+		$instance2 = PageApprovals::getInstance();
+
+		$this->assertSame( $instance1, $instance2 );
 	}
 
 }


### PR DESCRIPTION
For #3 

This adds the initial API stubs.

Use cases and presenters to come in a follow-up.