### PR TITLE
Create DB tables and persistence services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 	],
 	"require": {
 		"php": ">=8.1",
-		"composer/installers": "^2|^1.0.1"
+		"composer/installers": "^2|^1.0.1",
+		"jeroen/psr-log-test-doubles": "^3.2.0"
 	},
 	"require-dev": {
 		"vimeo/psalm": "^5.24.0",

--- a/extension.json
+++ b/extension.json
@@ -29,7 +29,8 @@
 	},
 
 	"Hooks": {
-		"OutputPageParserOutput": "ProfessionalWiki\\PageApprovals\\EntryPoints\\PageApprovalsHooks::onOutputPageParserOutput"
+		"OutputPageParserOutput": "ProfessionalWiki\\PageApprovals\\EntryPoints\\PageApprovalsHooks::onOutputPageParserOutput",
+		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\PageApprovals\\EntryPoints\\PageApprovalsHooks::onLoadExtensionSchemaUpdates"
 	},
 
 	"config": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,6 +26,26 @@ parameters:
 			path: src/Adapters/DatabaseApprovalLog.php
 
 		-
+			message: "#^Cannot access property \\$ac_categories on stdClass\\|true\\.$#"
+			count: 1
+			path: src/Adapters/DatabaseApproverRepository.php
+
+		-
+			message: "#^Method ProfessionalWiki\\\\PageApprovals\\\\Adapters\\\\DatabaseApproverRepository\\:\\:deserializeCategories\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Adapters/DatabaseApproverRepository.php
+
+		-
+			message: "#^Method ProfessionalWiki\\\\PageApprovals\\\\Adapters\\\\DatabaseApproverRepository\\:\\:serializeCategories\\(\\) has parameter \\$categories with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Adapters/DatabaseApproverRepository.php
+
+		-
+			message: "#^Parameter \\#2 \\$rows of method Wikimedia\\\\Rdbms\\\\IDatabase\\:\\:upsert\\(\\) expects array\\<array\\>, array\\<string, int\\|string\\> given\\.$#"
+			count: 1
+			path: src/Adapters/DatabaseApproverRepository.php
+
+		-
 			message: "#^Cannot access property \\$ah_html on stdClass\\|true\\.$#"
 			count: 1
 			path: src/Adapters/DatabaseHtmlRepository.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4,3 +4,13 @@ parameters:
 			message: "#^Property ProfessionalWiki\\\\PageApprovals\\\\Adapters\\\\AuthorityBasedApprovalAuthorizer\\:\\:\\$authority is never read, only written\\.$#"
 			count: 1
 			path: src/Adapters/AuthorityBasedApprovalAuthorizer.php
+
+		-
+			message: "#^Cannot access property \\$ah_html on stdClass\\|true\\.$#"
+			count: 1
+			path: src/Adapters/DatabaseHtmlRepository.php
+
+		-
+			message: "#^Parameter \\#2 \\$rows of method Wikimedia\\\\Rdbms\\\\IDatabase\\:\\:upsert\\(\\) expects array\\<array\\>, array\\<string, int\\|string\\> given\\.$#"
+			count: 1
+			path: src/Adapters/DatabaseHtmlRepository.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,6 +6,26 @@ parameters:
 			path: src/Adapters/AuthorityBasedApprovalAuthorizer.php
 
 		-
+			message: "#^Cannot access property \\$al_is_approved on stdClass\\|true\\.$#"
+			count: 1
+			path: src/Adapters/DatabaseApprovalLog.php
+
+		-
+			message: "#^Cannot access property \\$al_timestamp on stdClass\\|true\\.$#"
+			count: 1
+			path: src/Adapters/DatabaseApprovalLog.php
+
+		-
+			message: "#^Cannot access property \\$al_user_id on stdClass\\|true\\.$#"
+			count: 2
+			path: src/Adapters/DatabaseApprovalLog.php
+
+		-
+			message: "#^Parameter \\#2 \\$rows of method Wikimedia\\\\Rdbms\\\\IDatabase\\:\\:insert\\(\\) expects array\\<array\\>, array\\<string, int\\|string\\|null\\> given\\.$#"
+			count: 1
+			path: src/Adapters/DatabaseApprovalLog.php
+
+		-
 			message: "#^Cannot access property \\$ah_html on stdClass\\|true\\.$#"
 			count: 1
 			path: src/Adapters/DatabaseHtmlRepository.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -15,6 +15,21 @@
       <code><![CDATA[$row->al_user_id]]></code>
     </PossiblyInvalidPropertyFetch>
   </file>
+  <file src="src/Adapters/DatabaseApproverRepository.php">
+    <MixedArgument>
+      <code><![CDATA[$row->ac_categories]]></code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$categories]]></code>
+    </MixedArgumentTypeCoercion>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->deserializeCategories( $row->ac_categories )]]></code>
+      <code><![CDATA[string[]]]></code>
+    </MixedReturnTypeCoercion>
+    <PossiblyInvalidPropertyFetch>
+      <code><![CDATA[$row->ac_categories]]></code>
+    </PossiblyInvalidPropertyFetch>
+  </file>
   <file src="src/Adapters/DatabaseHtmlRepository.php">
     <MixedInferredReturnType>
       <code><![CDATA[?string]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,4 +5,15 @@
       <code><![CDATA[$authority]]></code>
     </UnusedProperty>
   </file>
+  <file src="src/Adapters/DatabaseHtmlRepository.php">
+    <MixedInferredReturnType>
+      <code><![CDATA[?string]]></code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code><![CDATA[$row->ah_html]]></code>
+    </MixedReturnStatement>
+    <PossiblyInvalidPropertyFetch>
+      <code><![CDATA[$row->ah_html]]></code>
+    </PossiblyInvalidPropertyFetch>
+  </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,6 +5,16 @@
       <code><![CDATA[$authority]]></code>
     </UnusedProperty>
   </file>
+  <file src="src/Adapters/DatabaseApprovalLog.php">
+    <MixedArgument>
+      <code><![CDATA[$row->al_timestamp]]></code>
+    </MixedArgument>
+    <PossiblyInvalidPropertyFetch>
+      <code><![CDATA[$row->al_is_approved]]></code>
+      <code><![CDATA[$row->al_timestamp]]></code>
+      <code><![CDATA[$row->al_user_id]]></code>
+    </PossiblyInvalidPropertyFetch>
+  </file>
   <file src="src/Adapters/DatabaseHtmlRepository.php">
     <MixedInferredReturnType>
       <code><![CDATA[?string]]></code>

--- a/sql/PageApprovals.sql
+++ b/sql/PageApprovals.sql
@@ -1,0 +1,20 @@
+CREATE TABLE /*_*/approval_log (
+    al_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    al_page_id INTEGER UNSIGNED NOT NULL,
+    al_timestamp BINARY(14) NOT NULL,
+    al_is_approved TINYINT(1) NOT NULL,
+    al_user_id INTEGER UNSIGNED NULL
+) /*$wgDBTableOptions*/;
+
+CREATE INDEX idx_page_timestamp ON /*_*/approval_log (al_page_id, al_timestamp);
+
+CREATE TABLE /*_*/approved_html (
+    ah_page_id INTEGER UNSIGNED PRIMARY KEY,
+    ah_html MEDIUMBLOB NOT NULL,
+    ah_timestamp BINARY(14) NOT NULL
+) /*$wgDBTableOptions*/;
+
+CREATE TABLE /*_*/approver_config (
+    ac_user_id INTEGER UNSIGNED PRIMARY KEY,
+    ac_categories BLOB NOT NULL
+) /*$wgDBTableOptions*/;

--- a/sql/PageApprovals.sql
+++ b/sql/PageApprovals.sql
@@ -1,5 +1,4 @@
 CREATE TABLE /*_*/approval_log (
-    al_id INTEGER PRIMARY KEY AUTOINCREMENT,
     al_page_id INTEGER UNSIGNED NOT NULL,
     al_timestamp BINARY(14) NOT NULL,
     al_is_approved TINYINT(1) NOT NULL,

--- a/src/Adapters/DatabaseApprovalLog.php
+++ b/src/Adapters/DatabaseApprovalLog.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Adapters;
+
+use ProfessionalWiki\PageApprovals\Application\ApprovalLog;
+use ProfessionalWiki\PageApprovals\Application\ApprovalState;
+use Wikimedia\Rdbms\IDatabase;
+
+class DatabaseApprovalLog implements ApprovalLog {
+
+	public function __construct(
+		private readonly IDatabase $database,
+	) {
+	}
+
+	public function getApprovalState( int $pageId ): ?ApprovalState {
+		$row = $this->database->selectRow(
+			'approval_log',
+			[ 'al_is_approved', 'al_timestamp', 'al_user_id' ],
+			[ 'al_page_id' => $pageId ],
+			__METHOD__,
+			[ 'ORDER BY' => 'al_timestamp DESC' ]
+		);
+
+		if ( $row === false ) {
+			return null;
+		}
+
+		return new ApprovalState(
+			pageId: $pageId,
+			isApproved: (bool)$row->al_is_approved,
+			approvalTimestamp: $this->binaryToUnixTimestamp( $row->al_timestamp ),
+			approverId: $row->al_user_id !== null ? (int)$row->al_user_id : null
+		);
+	}
+
+	private function binaryToUnixTimestamp( string $binaryTimestamp ): int {
+		return (int)wfTimestamp( TS_UNIX, $binaryTimestamp );
+	}
+
+	public function unapprovePage( int $pageId, ?int $userId ): void {
+		$this->logApprovalChange( $pageId, false, $userId );
+	}
+
+	public function approvePage( int $pageId, int $userId ): void {
+		$this->logApprovalChange( $pageId, true, $userId );
+	}
+
+	private function logApprovalChange( int $pageId, bool $isApproved, ?int $userId ): void {
+		$this->database->insert(
+			'approval_log',
+			[
+				'al_page_id' => $pageId,
+				'al_timestamp' => $this->database->timestamp(),
+				'al_is_approved' => $isApproved ? 1 : 0,
+				'al_user_id' => $userId,
+			],
+			__METHOD__
+		);
+	}
+
+}

--- a/src/Adapters/DatabaseApproverRepository.php
+++ b/src/Adapters/DatabaseApproverRepository.php
@@ -1,0 +1,61 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Adapters;
+
+use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
+use Wikimedia\Rdbms\IDatabase;
+
+class DatabaseApproverRepository implements ApproverRepository {
+
+	public function __construct(
+		private readonly IDatabase $database,
+	) {
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getApproverCategories( int $userId ): array {
+		$row = $this->database->selectRow(
+			'approver_config',
+			[ 'ac_categories' ],
+			[ 'ac_user_id' => $userId ],
+			__METHOD__
+		);
+
+		if ( $row === false ) {
+			return [];
+		}
+
+		return $this->deserializeCategories( $row->ac_categories );
+	}
+
+	/**
+	 * @param string[] $categoryNames
+	 */
+	public function setApproverCategories( int $userId, array $categoryNames ): void {
+		$this->database->upsert(
+			'approver_config',
+			[
+				'ac_user_id' => $userId,
+				'ac_categories' => $this->serializeCategories( $categoryNames ),
+			],
+			[ 'ac_user_id' ],
+			[
+				'ac_categories' => $this->serializeCategories( $categoryNames ),
+			],
+			__METHOD__
+		);
+	}
+
+	private function serializeCategories( array $categories ): string {
+		return implode( '|', $categories );
+	}
+
+	private function deserializeCategories( string $serializedCategories ): array {
+		return $serializedCategories === '' ? [] : explode( '|', $serializedCategories );
+	}
+
+}

--- a/src/Adapters/DatabaseHtmlRepository.php
+++ b/src/Adapters/DatabaseHtmlRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Adapters;
+
+use ProfessionalWiki\PageApprovals\Application\HtmlRepository;
+use Wikimedia\Rdbms\IDatabase;
+
+class DatabaseHtmlRepository implements HtmlRepository {
+
+	public function __construct(
+		private readonly IDatabase $database,
+	) {
+	}
+
+	public function getApprovedHtml( int $pageId ): ?string {
+		$row = $this->database->selectRow(
+			'approved_html',
+			[ 'ah_html' ],
+			[ 'ah_page_id' => $pageId ],
+			__METHOD__
+		);
+
+		if ( $row === false ) {
+			return null;
+		}
+
+		return $row->ah_html;
+	}
+
+	public function saveApprovedHtml( int $pageId, string $html ): void {
+		$this->database->upsert(
+			'approved_html',
+			[
+				'ah_page_id' => $pageId,
+				'ah_html' => $html,
+				'ah_timestamp' => $this->database->timestamp(),
+			],
+			[ 'ah_page_id' ],
+			[
+				'ah_html' => $html,
+				'ah_timestamp' => $this->database->timestamp(),
+			],
+			__METHOD__
+		);
+	}
+
+}

--- a/src/EntryPoints/PageApprovalsHooks.php
+++ b/src/EntryPoints/PageApprovalsHooks.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\PageApprovals\EntryPoints;
 
+use DatabaseUpdater;
 use OutputPage;
 use ParserOutput;
 use ProfessionalWiki\PageApprovals\PageApprovals;
@@ -14,6 +15,13 @@ class PageApprovalsHooks {
 		PageApprovals::getInstance()->newEvaluateApprovalStateAction()->evaluate(
 			pageId: $out->getWikiPage()->getId(),
 			currentPageHtml: $parserOutput->getRawText(),
+		);
+	}
+
+	public static function onLoadExtensionSchemaUpdates( DatabaseUpdater $updater ): void {
+		$updater->addExtensionTable(
+			'approval_log',
+			__DIR__ . '/../../sql/PageApprovals.sql'
 		);
 	}
 

--- a/tests/Adapters/DatabaseApprovalLogTest.php
+++ b/tests/Adapters/DatabaseApprovalLogTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Tests\Adapters;
+
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\PageApprovals\Adapters\DatabaseApprovalLog;
+use ProfessionalWiki\PageApprovals\Application\ApprovalLog;
+use ProfessionalWiki\PageApprovals\Application\ApprovalState;
+use Wikimedia\Timestamp\ConvertibleTimestamp;
+
+/**
+ * @covers \ProfessionalWiki\PageApprovals\Adapters\DatabaseApprovalLog
+ * @group Database
+ */
+class DatabaseApprovalLogTest extends MediaWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->tablesUsed[] = 'approval_log';
+	}
+
+	private function newApprovalLog(): ApprovalLog {
+		return new DatabaseApprovalLog( $this->db );
+	}
+
+	public function testGetApprovalStateReturnsNullForNonexistentPage(): void {
+		$log = $this->newApprovalLog();
+
+		$this->assertNull( $log->getApprovalState( 404 ) );
+	}
+
+	public function testApprovePage(): void {
+		$log = $this->newApprovalLog();
+		$pageId = 1;
+		$userId = 42;
+
+		$log->approvePage( $pageId, $userId );
+
+		$state = $log->getApprovalState( $pageId );
+		$this->assertInstanceOf( ApprovalState::class, $state );
+		$this->assertTrue( $state->isApproved );
+		$this->assertSame( $pageId, $state->pageId );
+		$this->assertSame( $userId, $state->approverId );
+		$this->assertEqualsWithDelta( time(), $state->approvalTimestamp, 2 );
+	}
+
+	public function testUnapprovePage(): void {
+		$log = $this->newApprovalLog();
+		$pageId = 2;
+		$userId = 24;
+
+		$log->approvePage( $pageId, $userId );
+		$log->unapprovePage( $pageId, $userId );
+
+		$state = $log->getApprovalState( $pageId );
+		$this->assertInstanceOf( ApprovalState::class, $state );
+		$this->assertFalse( $state->isApproved );
+		$this->assertSame( $pageId, $state->pageId );
+		$this->assertSame( $userId, $state->approverId );
+		$this->assertEqualsWithDelta( time(), $state->approvalTimestamp, 2 );
+	}
+
+	public function testUnapprovePageWithNullUserId(): void {
+		$log = $this->newApprovalLog();
+		$pageId = 3;
+
+		$log->approvePage( $pageId, 42 );
+		$log->unapprovePage( $pageId, null );
+
+		$state = $log->getApprovalState( $pageId );
+		$this->assertInstanceOf( ApprovalState::class, $state );
+		$this->assertFalse( $state->isApproved );
+		$this->assertSame( $pageId, $state->pageId );
+		$this->assertNull( $state->approverId );
+	}
+
+	public function testGetApprovalStateReturnsLatestState(): void {
+		$log = $this->newApprovalLog();
+		$pageId = 4;
+
+		ConvertibleTimestamp::setFakeTime( '20230101000000' );
+		$log->approvePage( $pageId, 1 );
+
+		ConvertibleTimestamp::setFakeTime( '20230102000000' );
+		$log->unapprovePage( $pageId, 2 );
+
+		ConvertibleTimestamp::setFakeTime( '20230103000000' );
+		$log->approvePage( $pageId, 3 );
+
+		ConvertibleTimestamp::setFakeTime( '20230104000000' );
+		$log->approvePage( $pageId + 1, 4 );
+
+		$state = $log->getApprovalState( $pageId );
+		$this->assertInstanceOf( ApprovalState::class, $state );
+		$this->assertTrue( $state->isApproved );
+		$this->assertSame( $pageId, $state->pageId );
+		$this->assertSame( 3, $state->approverId );
+		$this->assertSame( strtotime( '20230103000000' ), $state->approvalTimestamp );
+	}
+
+}

--- a/tests/Adapters/DatabaseApproverRepositoryTest.php
+++ b/tests/Adapters/DatabaseApproverRepositoryTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Tests\Adapters;
+
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\PageApprovals\Adapters\DatabaseApproverRepository;
+use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
+
+/**
+ * @covers \ProfessionalWiki\PageApprovals\Adapters\DatabaseApproverRepository
+ * @group Database
+ */
+class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->tablesUsed[] = 'approver_config';
+	}
+
+	private function newRepository(): ApproverRepository {
+		return new DatabaseApproverRepository( $this->db );
+	}
+
+	public function testGetApproverCategoriesReturnsEmptyArrayForNonexistentUser(): void {
+		$repository = $this->newRepository();
+
+		$this->assertSame( [], $repository->getApproverCategories( 404 ) );
+	}
+
+	public function testSetAndGetApproverCategories(): void {
+		$repository = $this->newRepository();
+		$userId = 1;
+		$categories = [ 'Category1', 'Category2', 'Category3' ];
+
+		$repository->setApproverCategories( $userId, $categories );
+
+		$this->assertSame( $categories, $repository->getApproverCategories( $userId ) );
+	}
+
+	public function testUpdateApproverCategories(): void {
+		$repository = $this->newRepository();
+		$userId = 1;
+		$initialCategories = [ 'Category1', 'Category2' ];
+		$updatedCategories = [ 'Category2', 'Category3', 'Category4' ];
+
+		$repository->setApproverCategories( $userId, $initialCategories );
+		$repository->setApproverCategories( $userId, $updatedCategories );
+
+		$this->assertSame( $updatedCategories, $repository->getApproverCategories( $userId ) );
+	}
+
+	public function testSetEmptyCategoryList(): void {
+		$repository = $this->newRepository();
+		$userId = 1;
+		$initialCategories = [ 'Category1', 'Category2' ];
+		$emptyCategories = [];
+
+		$repository->setApproverCategories( $userId, $initialCategories );
+		$repository->setApproverCategories( $userId, $emptyCategories );
+
+		$this->assertSame( $emptyCategories, $repository->getApproverCategories( $userId ) );
+	}
+
+	public function testMultipleUsers(): void {
+		$repository = $this->newRepository();
+		$user1Id = 1;
+		$user2Id = 2;
+		$categories1 = [ 'Category1', 'Category2' ];
+		$categories2 = [ 'Category3', 'Category4' ];
+
+		$repository->setApproverCategories( $user1Id, $categories1 );
+		$repository->setApproverCategories( $user2Id, $categories2 );
+
+		$this->assertSame( $categories1, $repository->getApproverCategories( $user1Id ) );
+		$this->assertSame( $categories2, $repository->getApproverCategories( $user2Id ) );
+	}
+
+	/**
+	 * @dataProvider provideCategoryTestCases
+	 */
+	public function testCategorySerializationAndDeserialization( array $categories, string $caseName ): void {
+		$repository = $this->newRepository();
+		$userId = 42;
+
+		$repository->setApproverCategories( $userId, $categories );
+		$retrievedCategories = $repository->getApproverCategories( $userId );
+
+		$this->assertSame(
+			$categories,
+			$retrievedCategories,
+			"Failed to correctly serialize and deserialize categories for case: $caseName"
+		);
+	}
+
+	public static function provideCategoryTestCases(): \Generator {
+		yield 'Categories with spaces' => [
+			[
+				'Category with spaces',
+				'Another category with spaces'
+			],
+			'Categories with spaces'
+		];
+
+		yield 'Categories with special characters' => [
+			[
+				'Category:Subcategory',
+				'Category_with_underscores',
+				'Category&with&ampersands'
+			],
+			'Categories with special characters'
+		];
+
+		yield 'Unicode categories' => [
+			[
+				'カテゴリ',
+				'Категория',
+				'فئة'
+			],
+			'Unicode categories'
+		];
+
+		yield 'Empty category list' => [
+			[],
+			'Empty category list'
+		];
+
+		yield 'Single category' => [
+			[ 'SingleCategory' ],
+			'Single category'
+		];
+
+		yield 'Category with leading/trailing spaces' => [
+			[
+				' Leading space',
+				'Trailing space ',
+				' Both sides '
+			],
+			'Category with leading/trailing spaces'
+		];
+	}
+
+}

--- a/tests/Adapters/DatabaseHtmlRepositoryTest.php
+++ b/tests/Adapters/DatabaseHtmlRepositoryTest.php
@@ -15,6 +15,11 @@ use ProfessionalWiki\PageApprovals\Application\HtmlRepository;
  */
 class DatabaseHtmlRepositoryTest extends MediaWikiIntegrationTestCase {
 
+	protected function setUp(): void {
+		parent::setUp();
+		$this->tablesUsed[] = 'approved_html';
+	}
+
 	public function testReturnsNullForNonexistentPage(): void {
 		$repository = $this->newRepository();
 

--- a/tests/Adapters/DatabaseHtmlRepositoryTest.php
+++ b/tests/Adapters/DatabaseHtmlRepositoryTest.php
@@ -8,6 +8,7 @@ use IDatabase;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\PageApprovals\Adapters\DatabaseHtmlRepository;
 use ProfessionalWiki\PageApprovals\Application\HtmlRepository;
+use Wikimedia\Timestamp\ConvertibleTimestamp;
 
 /**
  * @covers \ProfessionalWiki\PageApprovals\Adapters\DatabaseHtmlRepository
@@ -57,6 +58,29 @@ class DatabaseHtmlRepositoryTest extends MediaWikiIntegrationTestCase {
 		$repository->saveApprovedHtml( 1, 'second' );
 
 		$this->assertSame( 'second', $repository->getApprovedHtml( 1 ) );
+	}
+
+	public function testTimestampIsSetCorrectly(): void {
+		$fakeTime = '20230615120000'; // 2023-06-15 12:00:00
+		ConvertibleTimestamp::setFakeTime( $fakeTime );
+
+		$this->newRepository()->saveApprovedHtml( 1, '<p>Test content</p>' );
+
+		$this->assertSame(
+			$fakeTime,
+			$this->getTimestampFromDatabase( 1 )
+		);
+
+		ConvertibleTimestamp::setFakeTime( false ); // Reset fake time
+	}
+
+	private function getTimestampFromDatabase( int $pageId ): string {
+		return $this->db->selectField(
+			'approved_html',
+			'ah_timestamp',
+			[ 'ah_page_id' => $pageId ],
+			__METHOD__
+		);
 	}
 
 }

--- a/tests/Adapters/DatabaseHtmlRepositoryTest.php
+++ b/tests/Adapters/DatabaseHtmlRepositoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Tests\Adapters;
+
+use IDatabase;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\PageApprovals\Adapters\DatabaseHtmlRepository;
+use ProfessionalWiki\PageApprovals\Application\HtmlRepository;
+
+/**
+ * @covers \ProfessionalWiki\PageApprovals\Adapters\DatabaseHtmlRepository
+ * @group Database
+ */
+class DatabaseHtmlRepositoryTest extends MediaWikiIntegrationTestCase {
+
+	public function testReturnsNullForNonexistentPage(): void {
+		$repository = $this->newRepository();
+
+		$repository->saveApprovedHtml( 1, 'first' );
+		$repository->saveApprovedHtml( 2, 'second' );
+
+		$this->assertNull( $this->newRepository()->getApprovedHtml( pageId: 404 ) );
+	}
+
+	private function newRepository(
+		IDatabase $db = null,
+	): HtmlRepository {
+		return new DatabaseHtmlRepository(
+			$db ?? $this->db,
+		);
+	}
+
+	public function testSaveAndRetrieveHtml(): void {
+		$repository = $this->newRepository();
+
+		$pageId = 2;
+		$html = '<p>Test content</p>';
+
+		$repository->saveApprovedHtml( 1, 'wrong' );
+		$repository->saveApprovedHtml( $pageId, $html );
+		$repository->saveApprovedHtml( 3, 'also wrong' );
+
+		$this->assertSame( $html, $repository->getApprovedHtml( $pageId ) );
+	}
+
+	public function testCanUpdateHtml(): void {
+		$repository = $this->newRepository();
+
+		$repository->saveApprovedHtml( 1, 'first' );
+		$repository->saveApprovedHtml( 1, 'second' );
+
+		$this->assertSame( 'second', $repository->getApprovedHtml( 1 ) );
+	}
+
+}

--- a/tests/Application/UseCases/EvaluateApprovalStateTest.php
+++ b/tests/Application/UseCases/EvaluateApprovalStateTest.php
@@ -2,12 +2,13 @@
 
 declare( strict_types = 1 );
 
-namespace ProfessionalWiki\PageApprovals\Application\UseCases;
+namespace ProfessionalWiki\PageApprovals\Tests\Application\UseCases;
 
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\PageApprovals\Adapters\InMemoryApprovalLog;
 use ProfessionalWiki\PageApprovals\Adapters\InMemoryHtmlRepository;
 use ProfessionalWiki\PageApprovals\Application\ApprovalLog;
+use ProfessionalWiki\PageApprovals\Application\UseCases\EvaluateApprovalState;
 
 /**
  * @covers \ProfessionalWiki\PageApprovals\Application\UseCases\EvaluateApprovalState


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/PageApprovals/issues/5

At first I added try-catch blocks to DatabaseHtmlRepository for error handling and logging. After some consideration, I removed them, as I could not justify the added complexity. Quite annoying to test. And it's somewhat unrelastic for one of those DB calls to fail. If the DB is broken, the code won't get to this point. And even if it does happen, the user experience or the dev experience won't be improved by the try-catch. 