### PR TITLE
Resources Load Fix

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -43,7 +43,7 @@
 	},
 
 	"ResourceModules": {
-		"ext.pageApprovals.modules": {
+		"ext.pageApprovals.resources": {
 			"scripts": [
 				"ApprovePage.js"
 			],


### PR DESCRIPTION
.CSS and .JS files were not loading. This PR fixes that. The reason we couldn't catch that earlier was probably that it was cached in the browser.
Before:
![before](https://github.com/ProfessionalWiki/PageApprovals/assets/15813104/5e3a88db-942e-46ca-aa96-83095113e630)


After:

![after](https://github.com/ProfessionalWiki/PageApprovals/assets/15813104/e033641b-0168-449e-9beb-b704a9de4d0f)
