### PR TITLE
Add PendingApprovalRetriever

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,6 +56,31 @@ parameters:
 			path: src/Adapters/DatabaseHtmlRepository.php
 
 		-
+			message: "#^Cannot access property \\$categories on array\\|bool\\|stdClass\\.$#"
+			count: 1
+			path: src/Adapters/DatabasePendingApprovalRetriever.php
+
+		-
+			message: "#^Cannot access property \\$page_namespace on array\\|bool\\|stdClass\\.$#"
+			count: 1
+			path: src/Adapters/DatabasePendingApprovalRetriever.php
+
+		-
+			message: "#^Cannot access property \\$page_title on array\\|bool\\|stdClass\\.$#"
+			count: 1
+			path: src/Adapters/DatabasePendingApprovalRetriever.php
+
+		-
+			message: "#^Cannot access property \\$rev_actor on array\\|bool\\|stdClass\\.$#"
+			count: 1
+			path: src/Adapters/DatabasePendingApprovalRetriever.php
+
+		-
+			message: "#^Cannot access property \\$rev_timestamp on array\\|bool\\|stdClass\\.$#"
+			count: 1
+			path: src/Adapters/DatabasePendingApprovalRetriever.php
+
+		-
 			message: "#^Cannot call method getRawText\\(\\) on ParserOutput\\|true\\.$#"
 			count: 1
 			path: src/Adapters/PageContentRetriever.php
@@ -64,4 +89,3 @@ parameters:
 			message: "#^Parameter \\#1 \\$database of class ProfessionalWiki\\\\PageApprovals\\\\Adapters\\\\DatabaseApprovalLog constructor expects Wikimedia\\\\Rdbms\\\\IDatabase, Wikimedia\\\\Rdbms\\\\IDatabase\\|false given\\.$#"
 			count: 1
 			path: src/PageApprovals.php
-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -41,6 +41,22 @@
       <code><![CDATA[$row->ah_html]]></code>
     </PossiblyInvalidPropertyFetch>
   </file>
+  <file src="src/Adapters/DatabasePendingApprovalRetriever.php">
+    <MixedArgument>
+      <code><![CDATA[$row->categories]]></code>
+      <code><![CDATA[$row->page_title]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$name]]></code>
+    </MixedAssignment>
+    <PossiblyInvalidPropertyFetch>
+      <code><![CDATA[$row->categories]]></code>
+      <code><![CDATA[$row->page_namespace]]></code>
+      <code><![CDATA[$row->page_title]]></code>
+      <code><![CDATA[$row->rev_actor]]></code>
+      <code><![CDATA[$row->rev_timestamp]]></code>
+    </PossiblyInvalidPropertyFetch>
+  </file>
   <file src="src/Adapters/PageContentRetriever.php">
     <PossiblyInvalidMethodCall>
       <code><![CDATA[getRawText]]></code>

--- a/src/Adapters/DatabasePendingApprovalRetriever.php
+++ b/src/Adapters/DatabasePendingApprovalRetriever.php
@@ -1,0 +1,137 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Adapters;
+
+use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
+use ProfessionalWiki\PageApprovals\Application\PendingApproval;
+use ProfessionalWiki\PageApprovals\Application\PendingApprovalRetriever;
+use TitleValue;
+use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\IResultWrapper;
+use Wikimedia\Rdbms\Subquery;
+
+class DatabasePendingApprovalRetriever implements PendingApprovalRetriever {
+
+	public function __construct(
+		private IDatabase $db,
+		private ApproverRepository $approverRepository,
+		private int $limit = 500
+	) {
+	}
+
+	/**
+	 * @return PendingApproval[]
+	 */
+	public function getPendingApprovalsForApprover( int $approverId ): array {
+		$approverCategories = $this->approverRepository->getApproverCategories( $approverId );
+
+		if ( $approverCategories === [] ) {
+			return [];
+		}
+
+		return $this->buildPendingApprovals( $this->queryPendingApprovals( $approverCategories ) );
+	}
+
+	/**
+	 * @param string[] $categories
+	 */
+	private function queryPendingApprovals( array $categories ): IResultWrapper {
+		$latestApprovalSubquery = $this->getLatestApprovalSubquery();
+
+		return $this->db->select(
+			[
+				'page',
+				'revision',
+				'categorylinks',
+				'latest_approval' => $latestApprovalSubquery
+			],
+			[
+				'page_id',
+				'page_namespace',
+				'page_title',
+				'rev_timestamp',
+				'rev_actor',
+				'GROUP_CONCAT(DISTINCT cl_to) AS categories',
+				'latest_approval.al_is_approved',
+				'latest_approval.al_timestamp'
+			],
+			[
+				'cl_to' => $categories,
+				$this->db->makeList(
+					[
+						'latest_approval.al_is_approved' => 0,
+						'latest_approval.al_is_approved IS NULL'
+					],
+					IDatabase::LIST_OR
+				)
+			],
+			__METHOD__,
+			[
+				'GROUP BY' => 'page_id',
+				'LIMIT' => $this->limit
+			],
+			[
+				'revision' => [ 'INNER JOIN', 'page_latest = rev_id' ],
+				'categorylinks' => [ 'INNER JOIN', 'page_id = cl_from' ],
+				'latest_approval' => [ 'LEFT JOIN', 'page_id = latest_approval.al_page_id' ]
+			]
+		);
+	}
+
+	private function getLatestApprovalSubquery(): Subquery {
+		return $this->db->buildSelectSubquery(
+			'approval_log',
+			[ 'al_page_id', 'al_is_approved', 'al_timestamp' ],
+			[],
+			__METHOD__,
+			[ 'ORDER BY' => 'al_timestamp DESC' ],
+			[
+				$this->db->buildSelectSubquery(
+					'approval_log',
+					'MAX(al_timestamp)',
+					'al_page_id = outer_approval_log.al_page_id',
+					__METHOD__
+				) . ' = al_timestamp'
+			]
+		);
+	}
+
+	/**
+	 * @return PendingApproval[]
+	 */
+	private function buildPendingApprovals( IResultWrapper $res ): array {
+		$pendingApprovals = [];
+
+		foreach ( $res as $row ) {
+			$title = new TitleValue( (int)$row->page_namespace, $row->page_title );
+			$categories = explode( ',', $row->categories );
+			$lastEditUserName = $this->getUserNameFromActor( (int)$row->rev_actor );
+
+			$pendingApprovals[] = new PendingApproval(
+				$title,
+				$categories,
+				(int)$row->rev_timestamp,
+				$lastEditUserName
+			);
+		}
+
+		return $pendingApprovals;
+	}
+
+	private function getUserNameFromActor( int $actorId ): string {
+		$name = $this->db->selectField(
+			'actor',
+			'actor_name',
+			[ 'actor_id' => $actorId ],
+			__METHOD__
+		);
+
+		if ( is_string( $name ) ) {
+			return $name;
+		}
+
+		return '';
+	}
+}

--- a/src/Adapters/InMemoryApproverRepository.php
+++ b/src/Adapters/InMemoryApproverRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Adapters;
+
+use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
+
+class InMemoryApproverRepository implements ApproverRepository {
+
+	/**
+	 * @var array<int, string[]>
+	 */
+	private array $categoriesByUserId = [];
+
+	/**
+	 * @return string[]
+	 */
+	public function getApproverCategories( int $userId ): array {
+		return $this->categoriesByUserId[$userId] ?? [];
+	}
+
+	/**
+	 * @param string[] $categoryNames
+	 */
+	public function setApproverCategories( int $userId, array $categoryNames ): void {
+		$this->categoriesByUserId[$userId] = $categoryNames;
+	}
+
+}

--- a/src/Application/PendingApproval.php
+++ b/src/Application/PendingApproval.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Application;
+
+use TitleValue;
+
+class PendingApproval {
+
+	/**
+	 * @param string[] $categories
+	 */
+	public function __construct(
+		public readonly TitleValue $title,
+		public readonly array $categories,
+		public readonly int $lastEditTimestamp,
+		public readonly string $lastEditUserName,
+	) {
+	}
+
+}

--- a/src/Application/PendingApprovalRetriever.php
+++ b/src/Application/PendingApprovalRetriever.php
@@ -1,0 +1,14 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Application;
+
+interface PendingApprovalRetriever {
+
+	/**
+	 * @return PendingApproval[]
+	 */
+	public function getPendingApprovalsForApprover( int $approverId ): array;
+
+}

--- a/src/Application/UseCases/EvaluateApprovalState.php
+++ b/src/Application/UseCases/EvaluateApprovalState.php
@@ -17,6 +17,7 @@ class EvaluateApprovalState {
 
 	public function evaluate( int $pageId, string $currentPageHtml ): void {
 		if ( $currentPageHtml !== $this->getApprovedHtmlForPage( $pageId ) ) {
+			// TODO: verify only add record if page is approved
 			$this->unapprovePage( $pageId );
 		}
 	}

--- a/src/EntryPoints/PageApprovalsHooks.php
+++ b/src/EntryPoints/PageApprovalsHooks.php
@@ -13,6 +13,7 @@ class PageApprovalsHooks {
 
 	public static function onOutputPageParserOutput( OutputPage $out, ParserOutput $parserOutput ): void {
 		if ( $out->isArticle() ) {
+			// TODO: verify called only once
 			PageApprovals::getInstance()->newEvaluateApprovalStateAction()->evaluate(
 				pageId: $out->getWikiPage()->getId(),
 				currentPageHtml: $parserOutput->getRawText(),

--- a/tests/Adapters/DatabasePendingApprovalRetrieverTest.php
+++ b/tests/Adapters/DatabasePendingApprovalRetrieverTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Tests\Adapters;
+
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\PageApprovals\Adapters\DatabasePendingApprovalRetriever;
+use ProfessionalWiki\PageApprovals\Adapters\InMemoryApproverRepository;
+use ProfessionalWiki\PageApprovals\Application\PendingApproval;
+use Title;
+use WikiPage;
+
+/**
+ * @covers \ProfessionalWiki\PageApprovals\Adapters\DatabasePendingApprovalRetriever
+ * @group Database
+ */
+class DatabasePendingApprovalRetrieverTest extends MediaWikiIntegrationTestCase {
+
+	private DatabasePendingApprovalRetriever $retriever;
+	private InMemoryApproverRepository $approverRepository;
+	private int $pageCounter = 0;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->tablesUsed = [ 'page', 'revision', 'categorylinks', 'approval_log' ];
+
+		$this->approverRepository = new InMemoryApproverRepository();
+		$this->retriever = new DatabasePendingApprovalRetriever( $this->db, $this->approverRepository );
+	}
+
+	private function createUniqueTitle(): Title {
+		$this->pageCounter++;
+		return Title::newFromText( 'TestPage' . $this->pageCounter );
+	}
+
+	public function testGetPendingApprovalsForApproverWithNoCategories(): void {
+		$this->assertSame( [], $this->retriever->getPendingApprovalsForApprover( 1 ) );
+	}
+
+	public function testGetPendingApprovalsForApprover(): void {
+		$approverId = 1;
+		$approverCategories = [ 'Category1', 'Category2' ];
+		$this->approverRepository->setApproverCategories( $approverId, $approverCategories );
+
+		$title = $this->createUniqueTitle();
+		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title );
+		$this->editPage( $page, 'Test content' );
+		$this->addCategory( $page, 'Category1' );
+
+		$pageId = $page->getId();
+		$this->insertApprovalLogEntry( $pageId, false );
+
+		$pendingApprovals = $this->retriever->getPendingApprovalsForApprover( $approverId );
+
+		$this->assertCount( 1, $pendingApprovals );
+		$this->assertInstanceOf( PendingApproval::class, $pendingApprovals[0] );
+		$this->assertEquals( $title->getText(), $pendingApprovals[0]->title->getText() );
+		$this->assertContains( 'Category1', $pendingApprovals[0]->categories );
+	}
+
+	public function testGetPendingApprovalsExcludesApprovedPages(): void {
+		$approverId = 1;
+		$approverCategories = [ 'Category1' ];
+		$this->approverRepository->setApproverCategories( $approverId, $approverCategories );
+
+		$title1 = $this->createUniqueTitle();
+		$page1 = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title1 );
+		$this->editPage( $page1, 'Test content 1' );
+		$this->addCategory( $page1, 'Category1' );
+
+		$title2 = $this->createUniqueTitle();
+		$page2 = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title2 );
+		$this->editPage( $page2, 'Test content 2' );
+		$this->addCategory( $page2, 'Category1' );
+
+		$this->insertApprovalLogEntry( $page1->getId(), false );
+		$this->insertApprovalLogEntry( $page2->getId(), true );
+
+		$pendingApprovals = $this->retriever->getPendingApprovalsForApprover( $approverId );
+
+		$this->assertCount( 1, $pendingApprovals );
+		$this->assertEquals( $title1->getText(), $pendingApprovals[0]->title->getText() );
+	}
+
+	public function testGetPendingApprovalsReturnsLatestApprovalStatus(): void {
+		$approverId = 1;
+		$approverCategories = [ 'Category1' ];
+		$this->approverRepository->setApproverCategories( $approverId, $approverCategories );
+
+		$title = $this->createUniqueTitle();
+		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title );
+		$this->editPage( $page, 'Test content' );
+		$this->addCategory( $page, 'Category1' );
+
+		$pageId = $page->getId();
+		$this->insertApprovalLogEntry( $pageId, true, '20230101000000' );
+		$this->insertApprovalLogEntry( $pageId, false, '20230102000000' );
+
+		$pendingApprovals = $this->retriever->getPendingApprovalsForApprover( $approverId );
+
+		$this->assertCount( 1, $pendingApprovals );
+		$this->assertEquals( $title->getText(), $pendingApprovals[0]->title->getText() );
+	}
+
+	public function testGetPendingApprovalsRespectsLimit(): void {
+		$approverId = 1;
+		$approverCategories = [ 'Category1' ];
+		$this->approverRepository->setApproverCategories( $approverId, $approverCategories );
+
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$title = $this->createUniqueTitle();
+			$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title );
+			$this->editPage( $page, "Test content $i" );
+			$this->addCategory( $page, 'Category1' );
+			$this->insertApprovalLogEntry( $page->getId(), false );
+		}
+
+		$retriever = new DatabasePendingApprovalRetriever( $this->db, $this->approverRepository, 2 );
+		$pendingApprovals = $retriever->getPendingApprovalsForApprover( $approverId );
+
+		$this->assertCount( 2, $pendingApprovals );
+	}
+
+	private function addCategory( WikiPage $page, string $category ): void {
+		$content = $page->getContent();
+		$text = $content->getText();
+		$newText = $text . "\n[[Category:$category]]";
+		$this->editPage( $page, $newText );
+	}
+
+	private function insertApprovalLogEntry( int $pageId, bool $isApproved, string $timestamp = null ): void {
+		$this->db->insert(
+			'approval_log',
+			[
+				'al_page_id' => $pageId,
+				'al_timestamp' => $timestamp ?? $this->db->timestamp(),
+				'al_is_approved' => $isApproved ? 1 : 0,
+				'al_user_id' => 1
+			]
+		);
+	}
+}


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/PageApprovals/issues/24

`DatabasePendingApprovalRetriever` and `DatabasePendingApprovalRetrieverTest` are, in large part, AI-generated, and I have not fully reviewed them from first principles yet.

Query turned out to be more complex than I had imagined, but I don't see a way to simplify