### PR TITLE
Added seperate HTML template for Approval Status

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -52,7 +52,10 @@
 			],
 			"dependencies": [
 			],
-			"messages": []
+			"messages": [
+				"pageapprovals-status-approved",
+				"pageapprovals-status-not-approved"
+			]
 		}
 	},
 

--- a/extension.json
+++ b/extension.json
@@ -51,8 +51,6 @@
 				"PageApprovalsStyles.css"
 			],
 			"dependencies": [
-				"mediawiki.util",
-				"mediawiki.api"
 			],
 			"messages": []
 		}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -86,7 +86,17 @@ parameters:
 			path: src/Adapters/PageHtmlRetriever.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: src/EntryPoints/PageApprovalsHooks.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: src/EntryPoints/PageApprovalsHooks.php
+
+		-
+			message: "#^Ternary operator condition is always false\\.$#"
 			count: 1
 			path: src/EntryPoints/PageApprovalsHooks.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="src/Adapters/AuthorityBasedApprovalAuthorizer.php">
     <UnusedProperty>
       <code><![CDATA[$authority]]></code>
@@ -64,9 +64,14 @@
   </file>
   <file src="src/EntryPoints/PageApprovalsHooks.php">
     <RedundantCondition>
+      <code><![CDATA["pageapprovals-status-not-approved"]]></code>
       <code><![CDATA[$isAnApproverForPageCategory]]></code>
       <code><![CDATA[$isUserAnApprover]]></code>
     </RedundantCondition>
+    <TypeDoesNotContainType>
+      <code><![CDATA[$isPageApproved]]></code>
+      <code><![CDATA[$isPageApproved]]></code>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/PageApprovals.php">
     <FalsableReturnStatement>

--- a/resources/ApprovePage.js
+++ b/resources/ApprovePage.js
@@ -3,17 +3,23 @@ const restClient = new mw.Rest();
 function sendApprovalRequest( approve ) {
 	const pageId = mw.config.get( 'wgArticleId' );
 	const endpoint = `/page-approvals/v0/page/${ pageId }/${ approve ? 'approve' : 'unapprove' }`;
-	const csrfToken = mw.user.tokens.values.csrfToken;
 
-	restClient.post( endpoint, { token: csrfToken } )
-		.then( response => {
-			console.log( 'Request successful:', response );
-			mw.notify( 'Request successful: ' + JSON.stringify( response ) );
-		} )
+	restClient.post( endpoint )
+		.then( response => handleApprovalResponse( approve ) )
 		.catch( error => {
 			console.error( 'API request failed:', error );
 			mw.notify( 'API request failed: ' + error, { type: 'error' } );
 		} );
+}
+
+function handleApprovalResponse( approve ) {
+	const message = approve ? 'Page approved' : 'Page unapproved';
+	const statusMessage = mw.message( approve ? 'pageapprovals-status-approved' : 'pageapprovals-status-not-approved' ).text();
+	$( '.page-approval-status' ).text( statusMessage );
+	mw.notify( message, { type: 'success' } );
+
+	$( '#approveButton' ).toggle( !approve );
+	$( '#unapproveButton' ).toggle( approve );
 }
 
 $( '#approveButton, #unapproveButton' ).click( function() {

--- a/src/EntryPoints/PageApprovalsHooks.php
+++ b/src/EntryPoints/PageApprovalsHooks.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\PageApprovals\EntryPoints;
 use DatabaseUpdater;
 use OutputPage;
 use ParserOutput;
+use TemplateParser;
 use ProfessionalWiki\PageApprovals\PageApprovals;
 
 class PageApprovalsHooks {
@@ -41,39 +42,26 @@ class PageApprovalsHooks {
 			return;
 		}
 
+		$templateParser = new TemplateParser( __DIR__ . '/../../templates/' );
+
 		// TODO: Build logic for all hardcoded Booleans
 		$isUserAnApprover = true;
 		$isPageApproved = false;
 		$isAnApproverForPageCategory = true;
 
-		self::showApprovalStatus( $out, $isPageApproved );
+		$context = [
+			'isPageApproved' => $isPageApproved,
+			'canApprove' => $isAnApproverForPageCategory && $isUserAnApprover,
+			'approveButtonText' => $out->msg( 'pageapprovals-approve-button' )->text(),
+			'unapproveButtonText' => $out->msg( 'pageapprovals-unapprove-button' )->text(),
+			'approvalStatusMessage' => $out->msg(
+				$isPageApproved ? "pageapprovals-status-approved" : "pageapprovals-status-not-approved"
+			)->text()
+		];
 
-		// @phpstan-ignore-next-line
-		$canApprove = $isUserAnApprover && $isAnApproverForPageCategory;
-
-		if ( $canApprove ) {
-			self::showApprovalButton( $out, $isPageApproved );
-		}
-
+		$html = $templateParser->processTemplate( 'PageApprovalStatus', $context );
+		$out->addHTML( $html );
 		$out->addModules( 'ext.pageApprovals.resources' );
-	}
-
-	private static function showApprovalStatus( OutputPage $out, bool $isPageApproved ): void {
-		$messageKey = $isPageApproved ? "pageapprovals-status-approved" : "pageapprovals-status-not-approved";
-		$message = $out->msg( $messageKey )->text();
-		$out->addHTML( "<div class='page-approval-status'>{$message}</div>" );
-	}
-
-	private static function showApprovalButton( OutputPage $out, bool $isPageApproved ): void {
-		if ( $isPageApproved ) {
-			$unapproveButtonText = $out->msg( 'pageapprovals-unapprove-button' )->text();
-			$unapproveButtonHtml = "<button id='unapproveButton'>{$unapproveButtonText}</button>";
-			$out->addHTML( $unapproveButtonHtml );
-		} else {
-			$approveButtonText = $out->msg( 'pageapprovals-approve-button' )->text();
-			$approveButtonHtml = "<button id='approveButton'>{$approveButtonText}</button>";
-			$out->addHTML( $approveButtonHtml );
-		}
 	}
 
 }

--- a/templates/PageApprovalStatus.mustache
+++ b/templates/PageApprovalStatus.mustache
@@ -1,10 +1,11 @@
 <div class='page-approval-status'>{{approvalStatusMessage}}</div>
-
 {{#canApprove}}
 	{{#isPageApproved}}
 		<button id='unapproveButton'>{{unapproveButtonText}}</button>
+		<button id='approveButton' style="display: none">{{approveButtonText}}</button>
 	{{/isPageApproved}}
 	{{^isPageApproved}}
 		<button id='approveButton'>{{approveButtonText}}</button>
+		<button id='unapproveButton' style="display: none">{{unapproveButtonText}}</button>
 	{{/isPageApproved}}
 {{/canApprove}}

--- a/templates/PageApprovalStatus.mustache
+++ b/templates/PageApprovalStatus.mustache
@@ -1,0 +1,10 @@
+<div class='page-approval-status'>{{approvalStatusMessage}}</div>
+
+{{#canApprove}}
+	{{#isPageApproved}}
+		<button id='unapproveButton'>{{unapproveButtonText}}</button>
+	{{/isPageApproved}}
+	{{^isPageApproved}}
+		<button id='approveButton'>{{approveButtonText}}</button>
+	{{/isPageApproved}}
+{{/canApprove}}


### PR DESCRIPTION
Context:

https://chat.professional.wiki/pro-wiki/pl/kas94puudtg7icjt9ndsnaf6ra

JS and CSS loads as usual.

![image](https://github.com/ProfessionalWiki/PageApprovals/assets/15813104/a6b1f4a4-6545-4050-84e4-27016664897c)
