### PR TITLE
Replace MW Rest with Ajax

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -53,7 +53,10 @@
 			],
 			"dependencies": [
 			],
-			"messages": []
+			"messages": [
+				"pageapprovals-status-approved",
+				"pageapprovals-status-not-approved"
+			]
 		}
 	},
 

--- a/extension.json
+++ b/extension.json
@@ -25,6 +25,7 @@
 
 	"AutoloadNamespaces": {
 		"ProfessionalWiki\\PageApprovals\\": "src/",
+		"ProfessionalWiki\\PageApprovals\\Templates\\": "templates/",
 		"ProfessionalWiki\\PageApprovals\\Tests\\": "tests/"
 	},
 

--- a/resources/ApprovePage.js
+++ b/resources/ApprovePage.js
@@ -1,22 +1,28 @@
-const restClient = new mw.Rest();
-
 function sendApprovalRequest( approve ) {
 	const pageId = mw.config.get( 'wgArticleId' );
-	const endpoint = `/page-approvals/v0/page/${ pageId }/${ approve ? 'approve' : 'unapprove' }`;
-	const csrfToken = mw.user.tokens.values.csrfToken;
+	const endpoint = '/rest.php/page-approvals/v0/page/' + pageId + '/' + (approve ? 'approve' : 'unapprove');
 
-	restClient.post( endpoint, { token: csrfToken } )
-		.then( response => {
-			console.log( 'Request successful:', response );
-			mw.notify( 'Request successful: ' + JSON.stringify( response ) );
-		} )
-		.catch( error => {
-			console.error( 'API request failed:', error );
+	$.ajax( {
+		url: endpoint,
+		type: 'POST',
+		contentType: 'application/json',
+		success: () => {
+			const message = approve ? 'Page approved' : 'Page unapproved';
+			const statusMessage = approve ? mw.message( 'pageapprovals-status-approved' ).text() : mw.message(
+				'pageapprovals-status-not-approved' ).text();
+			$( '.page-approval-status' ).text( statusMessage );
+			mw.notify( message, { type: 'success' } );
+
+			$( '#approveButton' ).toggle( !approve );
+			$( '#unapproveButton' ).toggle( approve );
+		},
+		error: function( xhr, status, error ) {
 			mw.notify( 'API request failed: ' + error, { type: 'error' } );
-		} );
+		}
+	} );
 }
 
-$( '#approveButton, #unapproveButton' ).click( function() {
+$( document ).on( 'click', '#approveButton, #unapproveButton', function() {
 	const approve = $( this ).is( '#approveButton' );
 	sendApprovalRequest( approve );
 } );

--- a/templates/PageApprovalStatus.mustache
+++ b/templates/PageApprovalStatus.mustache
@@ -3,8 +3,10 @@
 {{#canApprove}}
 	{{#isPageApproved}}
 		<button id='unapproveButton'>{{unapproveButtonText}}</button>
+		<button id='approveButton' style="display: none">{{approveButtonText}}</button>
 	{{/isPageApproved}}
 	{{^isPageApproved}}
 		<button id='approveButton'>{{approveButtonText}}</button>
+		<button id='unapproveButton' style="display: none">{{unapproveButtonText}}</button>
 	{{/isPageApproved}}
 {{/canApprove}}


### PR DESCRIPTION
@malberts **MW.Rest** isn't working for me and always gives me an error even when its 200 response from API. Is there a strong reason to use it? AJAX is available by default and is only better than MW.rest and it works.


https://github.com/ProfessionalWiki/PageApprovals/assets/15813104/8d7abd6d-2a07-4c8f-9405-a20406dbc2a8



