### PR TITLE
Add category normalization

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -20,9 +20,6 @@
       <code><![CDATA[$row->ac_categories]]></code>
       <code><![CDATA[$row->categories]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$categories]]></code>
-    </MixedArgumentTypeCoercion>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$approvers]]></code>
       <code><![CDATA[$this->deserializeCategories( $row->ac_categories )]]></code>

--- a/src/Adapters/DatabaseApproverRepository.php
+++ b/src/Adapters/DatabaseApproverRepository.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\PageApprovals\Adapters;
 
 use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
+use Title;
 use Wikimedia\Rdbms\IDatabase;
 
 class DatabaseApproverRepository implements ApproverRepository {
@@ -75,7 +76,15 @@ class DatabaseApproverRepository implements ApproverRepository {
 	}
 
 	private function serializeCategories( array $categories ): string {
-		return implode( '|', $categories );
+		return implode( '|', array_unique( array_map(
+			fn ( string $category ) => $this->normalizeCategoryTitle( $category ),
+			$categories
+		) ) );
+	}
+
+	private function normalizeCategoryTitle( string $title ): string {
+		// TODO: Confirm database is not accessed, otherwise use TitleValue::tryNew()
+		return Title::newFromText( $title )?->getText() ?? '';
 	}
 
 	private function deserializeCategories( string $serializedCategories ): array {

--- a/tests/Adapters/DatabaseApproverRepositoryTest.php
+++ b/tests/Adapters/DatabaseApproverRepositoryTest.php
@@ -80,7 +80,11 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @dataProvider provideCategoryTestCases
 	 */
-	public function testCategorySerializationAndDeserialization( array $categories, string $caseName ): void {
+	public function testCategorySerializationAndDeserialization(
+		array $categories,
+		array $expectedRetrievedCategories,
+		string $caseName
+	): void {
 		$repository = $this->newRepository();
 		$userId = 42;
 
@@ -88,7 +92,7 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 		$retrievedCategories = $repository->getApproverCategories( $userId );
 
 		$this->assertSame(
-			$categories,
+			$expectedRetrievedCategories,
 			$retrievedCategories,
 			"Failed to correctly serialize and deserialize categories for case: $caseName"
 		);
@@ -131,6 +135,10 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 				'Category with spaces',
 				'Another category with spaces'
 			],
+			[
+				'Category with spaces',
+				'Another category with spaces'
+			],
 			'Categories with spaces'
 		];
 
@@ -138,6 +146,11 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 			[
 				'Category:Subcategory',
 				'Category_with_underscores',
+				'Category&with&ampersands'
+			],
+			[
+				'Subcategory',
+				'Category with underscores',
 				'Category&with&ampersands'
 			],
 			'Categories with special characters'
@@ -149,15 +162,22 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 				'Категория',
 				'فئة'
 			],
+			[
+				'カテゴリ',
+				'Категория',
+				'فئة'
+			],
 			'Unicode categories'
 		];
 
 		yield 'Empty category list' => [
 			[],
+			[],
 			'Empty category list'
 		];
 
 		yield 'Single category' => [
+			[ 'SingleCategory' ],
 			[ 'SingleCategory' ],
 			'Single category'
 		];
@@ -168,7 +188,26 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 				'Trailing space ',
 				' Both sides '
 			],
+			[
+				'Leading space',
+				'Trailing space',
+				'Both sides'
+			],
 			'Category with leading/trailing spaces'
+		];
+
+		yield 'Category with case insensitive letters' => [
+			[
+				'Foo Bar',
+				'foo Bar',
+				'Foo bar',
+				'foo bar'
+			],
+			[
+				'Foo Bar',
+				'Foo bar'
+			],
+			'Category with case insensitive letters'
 		];
 	}
 


### PR DESCRIPTION
We should normalize the saving or retrieval of categories from the `approver_config` table (DatabaseApproverRepository), or alternatively wherever the retrieved approver categories are used (AuthorityBasedApprovalAuthorizer in #33).

See also https://github.com/ProfessionalWiki/PageApprovals/pull/33#discussion_r1660167517