### PR TITLE
Check revision ID in API

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -71,12 +71,12 @@
 
 	"RestRoutes": [
 		{
-			"path": "/page-approvals/v0/page/{pageId}/approve",
+			"path": "/page-approvals/v0/revision/{revisionId}/approve",
 			"method": [ "POST" ],
 			"factory": "ProfessionalWiki\\PageApprovals\\PageApprovals::newApprovePageApi"
 		},
 		{
-			"path": "/page-approvals/v0/page/{pageId}/unapprove",
+			"path": "/page-approvals/v0/revision/{revisionId}/unapprove",
 			"method": [ "POST" ],
 			"factory": "ProfessionalWiki\\PageApprovals\\PageApprovals::newUnapprovePageApi"
 		}

--- a/resources/ApprovePage.js
+++ b/resources/ApprovePage.js
@@ -1,8 +1,8 @@
 const restClient = new mw.Rest();
 
 function sendApprovalRequest( approve ) {
-	const pageId = mw.config.get( 'wgArticleId' );
-	const endpoint = `/page-approvals/v0/page/${ pageId }/${ approve ? 'approve' : 'unapprove' }`;
+	const revisionId = mw.config.get( 'wgRevisionId' );
+	const endpoint = `/page-approvals/v0/revision/${ revisionId }/${ approve ? 'approve' : 'unapprove' }`;
 
 	restClient.post( endpoint )
 		.then( response => handleApprovalResponse( approve ) )

--- a/src/PageApprovals.php
+++ b/src/PageApprovals.php
@@ -38,7 +38,8 @@ class PageApprovals {
 			self::getInstance()->getApprovalLog(),
 			self::getInstance()->getHtmlRepository(),
 			self::getInstance()->getPageHtmlRetriever(),
-			MediaWikiServices::getInstance()->getWikiPageFactory()
+			MediaWikiServices::getInstance()->getWikiPageFactory(),
+			MediaWikiServices::getInstance()->getRevisionLookup()
 		);
 	}
 
@@ -46,7 +47,8 @@ class PageApprovals {
 		return new UnapprovePageApi(
 			self::getInstance()->newPageApprovalAuthorizer(),
 			self::getInstance()->getApprovalLog(),
-			MediaWikiServices::getInstance()->getWikiPageFactory()
+			MediaWikiServices::getInstance()->getWikiPageFactory(),
+			MediaWikiServices::getInstance()->getRevisionLookup()
 		);
 	}
 

--- a/tests/Adapters/PageHtmlRetrieverTest.php
+++ b/tests/Adapters/PageHtmlRetrieverTest.php
@@ -18,7 +18,7 @@ class PageHtmlRetrieverTest extends PageApprovalsIntegrationTest {
 		$retriever = $this->newPageHtmlRetriever();
 
 		$html = $retriever->getPageHtml(
-			$this->getIdOfExistingPage( 'Foo Bar', 'Lorem Ipsum' )
+			$this->createPageWithText( 'Lorem Ipsum' )->getId()
 		);
 
 		$this->assertSame( <<<EOT
@@ -36,11 +36,11 @@ EOT
 
 	public function testGetsLatestHtml(): void {
 		$retriever = $this->newPageHtmlRetriever();
-		$pageId = $this->getIdOfExistingPage( 'Foo Bar Baz' );
+		$page = $this->createPageWithText( 'Lorem Ipsum' );
 
-		$this->editPage( 'Foo Bar Baz', 'Dolor sit amet' );
+		$this->editPage( $page, 'Dolor sit amet' );
 
-		$html = $retriever->getPageHtml( $pageId );
+		$html = $retriever->getPageHtml( $page->getId() );
 
 		$this->assertSame( <<<EOT
 <p>Dolor sit amet

--- a/tests/PageApprovalsIntegrationTest.php
+++ b/tests/PageApprovalsIntegrationTest.php
@@ -4,16 +4,17 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\PageApprovals\Tests;
 
-use MediaWiki\MediaWikiServices;
 use Title;
 use WikiPage;
 
 class PageApprovalsIntegrationTest extends \MediaWikiIntegrationTestCase {
 
-	protected function getIdOfExistingPage( string $titleText, string $text = 'Whatever wikitext' ): int {
-		$title = Title::newFromText( $titleText );
-		$this->editPage( $title, $text );
-		return MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title )->getId();
+	protected function createPageWithText( string $text = 'Whatever wikitext' ): WikiPage {
+		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $this->createUniqueTitle() );
+
+		$this->editPage( $page, $text );
+
+		return $page;
 	}
 
 	protected function createPageWithCategories( array $categories = [] ): WikiPage {


### PR DESCRIPTION
For #37 

This replaces the page ID parameter with the revision ID. The page is retrieved from the revision.

Manually tested that the correct 409 response is returned when an outdated page is kept open for Approval or Unapproval.