### PR TITLE
Avoid persisting multiple unapproval logs

### DIFF
--- a/src/Application/UseCases/EvaluateApprovalState.php
+++ b/src/Application/UseCases/EvaluateApprovalState.php
@@ -16,8 +16,9 @@ class EvaluateApprovalState {
 	}
 
 	public function evaluate( int $pageId, string $currentPageHtml ): void {
-		if ( $currentPageHtml !== $this->getApprovedHtmlForPage( $pageId ) ) {
-			// TODO: verify only add record if page is approved
+		if ( $currentPageHtml !== $this->getApprovedHtmlForPage( $pageId )
+			&& $this->approvalLog->getApprovalState( $pageId )?->isApproved === true
+		) {
 			$this->unapprovePage( $pageId );
 		}
 	}

--- a/tests/Application/UseCases/EvaluateApprovalStateTest.php
+++ b/tests/Application/UseCases/EvaluateApprovalStateTest.php
@@ -36,7 +36,7 @@ class EvaluateApprovalStateTest extends TestCase {
 		return $approvalLog;
 	}
 
-	public function testPageIsUnapprovedUponMismatchingHtml(): void {
+	public function testApprovedPageGetsUnapprovedUponMismatchingHtml(): void {
 		$approvalLog = $this->newApprovalLogWithApprovedPage();
 
 		$htmlRepo = new InMemoryHtmlRepository();
@@ -66,6 +66,20 @@ class EvaluateApprovalStateTest extends TestCase {
 		$action->evaluate( self::PAGE_ID, 'same' );
 
 		$this->assertTrue( $approvalLog->getApprovalState( self::PAGE_ID )->isApproved );
+	}
+
+	public function testUnapprovedPageRemainsUnapproved(): void {
+		$approvalLog = new InMemoryApprovalLog();
+
+		$action = new EvaluateApprovalState(
+			htmlRepository: new InMemoryHtmlRepository(),
+			approvalLog: $approvalLog
+		);
+
+		$action->evaluate( self::PAGE_ID, 'different' );
+
+		// By asserting null, we verify that no additional "unapproved" record ended up in the log.
+		$this->assertNull( $approvalLog->getApprovalState( self::PAGE_ID ) );
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/PageApprovals/issues/56

Also verified manually by loading the page and checking whats in the DB afterwards.