### PR TITLE
Add Approver class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -106,26 +106,6 @@ parameters:
 			path: src/EntryPoints/Specials/SpecialManageApprovers.php
 
 		-
-			message: "#^Method ProfessionalWiki\\\\PageApprovals\\\\EntryPoints\\\\Specials\\\\SpecialManageApprovers\\:\\:handlePostRequest\\(\\) has parameter \\$approversCategories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/EntryPoints/Specials/SpecialManageApprovers.php
-
-		-
-			message: "#^Method ProfessionalWiki\\\\PageApprovals\\\\EntryPoints\\\\Specials\\\\SpecialManageApprovers\\:\\:processCategoryAction\\(\\) has parameter \\$currentCategories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/EntryPoints/Specials/SpecialManageApprovers.php
-
-		-
-			message: "#^Method ProfessionalWiki\\\\PageApprovals\\\\EntryPoints\\\\Specials\\\\SpecialManageApprovers\\:\\:renderHtml\\(\\) has parameter \\$approversCategories with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/EntryPoints/Specials/SpecialManageApprovers.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$approversCategories$#"
-			count: 1
-			path: src/EntryPoints/Specials/SpecialManageApprovers.php
-
-		-
 			message: "#^Parameter \\#1 \\$php of static method LightnCandy\\\\LightnCandy\\:\\:prepare\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/EntryPoints/Specials/SpecialManageApprovers.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -84,21 +84,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/EntryPoints/Specials/SpecialManageApprovers.php">
-    <InvalidDocblockParamName>
-      <code><![CDATA[$approversCategories]]></code>
-    </InvalidDocblockParamName>
-    <MixedArgument>
-      <code><![CDATA[$currentCategories]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$currentCategories]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$approver['username']]]></code>
-    </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$currentCategories]]></code>
-    </MixedAssignment>
     <PossiblyNullReference>
       <code><![CDATA[getId]]></code>
     </PossiblyNullReference>

--- a/src/Application/Approver.php
+++ b/src/Application/Approver.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PageApprovals\Application;
+
+class Approver {
+
+	/**
+	 * @param string[] $categories
+	 */
+	public function __construct(
+		public readonly string $username,
+		public readonly int $userId,
+		public readonly array $categories,
+	) {
+	}
+
+}

--- a/src/Application/UseCases/GetApproversWithCategories.php
+++ b/src/Application/UseCases/GetApproversWithCategories.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\PageApprovals\Application\UseCases;
 
 use MediaWiki\MediaWikiServices;
+use ProfessionalWiki\PageApprovals\Application\Approver;
 use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
 
 class GetApproversWithCategories {
@@ -15,7 +16,7 @@ class GetApproversWithCategories {
 	}
 
 	/**
-	 * @return array<array{username: string, userId: int, categories: string[]}>
+	 * @return array<Approver>
 	 */
 	public function getApproversWithCategories(): array {
 		$approversWithCategories = $this->approverRepository->getApproversWithCategories();
@@ -24,11 +25,11 @@ class GetApproversWithCategories {
 		$approvers = [];
 		foreach ( $approversWithCategories as $approver ) {
 			$user = $userFactory->newFromId( (int)$approver['userId'] );
-			$approvers[] = [
-				'username' => $user->getName(),
-				'userId' => $approver['userId'],
-				'categories' => $approver['categories']
-			];
+			$approvers[] = new Approver(
+				username: $user->getName(),
+				userId: $approver['userId'],
+				categories: $approver['categories']
+			);
 		}
 
 		return $approvers;


### PR DESCRIPTION
To pass around an object, instead of a complex array.

This came up because I saw the complex array typehint along with the missing typehints.