### PR TITLE
Return approval state in API response

### DIFF
--- a/src/EntryPoints/REST/ApprovePageApi.php
+++ b/src/EntryPoints/REST/ApprovePageApi.php
@@ -8,9 +8,11 @@ use MediaWiki\Page\WikiPageFactory;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use MediaWiki\Revision\RevisionLookup;
+use MediaWiki\User\UserIdentityLookup;
 use ProfessionalWiki\PageApprovals\Adapters\PageHtmlRetriever;
 use ProfessionalWiki\PageApprovals\Application\ApprovalAuthorizer;
 use ProfessionalWiki\PageApprovals\Application\ApprovalLog;
+use ProfessionalWiki\PageApprovals\Application\ApprovalState;
 use ProfessionalWiki\PageApprovals\Application\HtmlRepository;
 use Wikimedia\ParamValidator\ParamValidator;
 use WikiPage;
@@ -23,7 +25,8 @@ class ApprovePageApi extends SimpleHandler {
 		private HtmlRepository $htmlRepository,
 		private PageHtmlRetriever $pageHtmlRetriever,
 		private WikiPageFactory $wikiPageFactory,
-		private RevisionLookup $revisionLookup
+		private RevisionLookup $revisionLookup,
+		private UserIdentityLookup $userIdentityLookup
 	) {
 	}
 
@@ -49,7 +52,7 @@ class ApprovePageApi extends SimpleHandler {
 			$this->htmlRepository->saveApprovedHtml( $page->getId(), $html );
 		}
 
-		return $this->newSuccessResponse();
+		return $this->newSuccessResponse( $this->approvalLog->getApprovalState( $page->getId() ) );
 	}
 
 	private function getPageFromRevisionId( int $revisionId ): ?WikiPage {
@@ -66,8 +69,23 @@ class ApprovePageApi extends SimpleHandler {
 		return $revisionId === $page->getRevisionRecord()?->getId();
 	}
 
-	public function newSuccessResponse(): Response {
-		return $this->getResponseFactory()->createNoContent();
+	public function newSuccessResponse( ?ApprovalState $state ): Response {
+		if ( $state === null ) {
+			return $this->getResponseFactory()->createNoContent();
+		}
+
+		return $this->getResponseFactory()->createJson( [
+			'approvalTimestamp' => $state->approvalTimestamp,
+			'approver' => $this->getUserNameFromUserId( $state->approverId ),
+		] );
+	}
+
+	private function getUserNameFromUserId( ?int $userId ): ?string {
+		if ( $userId === null ) {
+			return null;
+		}
+
+		return $this->userIdentityLookup->getUserIdentityByUserId( $userId )?->getName();
 	}
 
 	public function newAuthorizationFailedResponse(): Response {

--- a/src/PageApprovals.php
+++ b/src/PageApprovals.php
@@ -39,7 +39,8 @@ class PageApprovals {
 			self::getInstance()->getHtmlRepository(),
 			self::getInstance()->getPageHtmlRetriever(),
 			MediaWikiServices::getInstance()->getWikiPageFactory(),
-			MediaWikiServices::getInstance()->getRevisionLookup()
+			MediaWikiServices::getInstance()->getRevisionLookup(),
+			MediaWikiServices::getInstance()->getUserIdentityLookup()
 		);
 	}
 
@@ -48,7 +49,8 @@ class PageApprovals {
 			self::getInstance()->newPageApprovalAuthorizer(),
 			self::getInstance()->getApprovalLog(),
 			MediaWikiServices::getInstance()->getWikiPageFactory(),
-			MediaWikiServices::getInstance()->getRevisionLookup()
+			MediaWikiServices::getInstance()->getRevisionLookup(),
+			MediaWikiServices::getInstance()->getUserIdentityLookup()
 		);
 	}
 


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/PageApprovals/issues/54

Also needed to show the new approval details on a page without refresh.