### PR TITLE
Add API response messages

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -12,5 +12,8 @@
 	"pageapprovals-approve-button": "Approve Page",
 	"pageapprovals-unapprove-button": "Unapprove Page",
 	"right-manage-approvers": "Manage approvers",
-	"action-manage-approvers": "manage approvers"
+	"action-manage-approvers": "manage approvers",
+	"pageapprovals-authorization-failed": "You are not authorized to perform this action.",
+	"pageapprovals-invalid-page": "Invalid page.",
+	"pageapprovals-outdated-revision": "The revision of this page is outdated."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -15,7 +15,10 @@
 	"action-manage-approvers": "manage approvers",
 	"pageapprovals-approved": "Page approved",
 	"pageapprovals-unapproved": "Page unapproved",
-	"pageapprovals-authorization-failed": "You are not authorized to perform this action.",
-	"pageapprovals-invalid-page": "Invalid page.",
-	"pageapprovals-outdated-revision": "The revision of this page is outdated."
+	"pageapprovals-approve-authorization-failed": "Approval failed. You are not authorized to approve this page.",
+	"pageapprovals-unapprove-authorization-failed": "Unapproval failed. You are not authorized to unapprove this page.",
+	"pageapprovals-approve-invalid-page": "Approval failed. This page does not exist.",
+	"pageapprovals-unapprove-invalid-page": "Unapproval failed. This page does not exist.",
+	"pageapprovals-approve-outdated-revision": "Approval failed. You can only approve the latest version of a page.",
+	"pageapprovals-unapprove-outdated-revision": "Unapproval failed. You can only unapprove the latest version of a page."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -13,6 +13,8 @@
 	"pageapprovals-unapprove-button": "Unapprove Page",
 	"right-manage-approvers": "Manage approvers",
 	"action-manage-approvers": "manage approvers",
+	"pageapprovals-approved": "Page approved",
+	"pageapprovals-unapproved": "Page unapproved",
 	"pageapprovals-authorization-failed": "You are not authorized to perform this action.",
 	"pageapprovals-invalid-page": "Invalid page.",
 	"pageapprovals-outdated-revision": "The revision of this page is outdated."

--- a/resources/ApprovePage.js
+++ b/resources/ApprovePage.js
@@ -5,15 +5,13 @@ function sendApprovalRequest( approve ) {
 	const endpoint = `/page-approvals/v0/revision/${ revisionId }/${ approve ? 'approve' : 'unapprove' }`;
 
 	restClient.post( endpoint )
-		.then( response => handleApprovalResponse( approve ) )
-		.catch( error => {
-			console.error( 'API request failed:', error );
-			mw.notify( 'API request failed: ' + error, { type: 'error' } );
+		.then( response => handleApprovalResponse( approve, response.message ) )
+		.catch( ( error, response ) => {
+			mw.notify( response.xhr.responseJSON.message || 'API request failed: ' + error, { type: 'error' } );
 		} );
 }
 
-function handleApprovalResponse( approve ) {
-	const message = approve ? 'Page approved' : 'Page unapproved';
+function handleApprovalResponse( approve, message ) {
 	const statusMessage = mw.message( approve ? 'pageapprovals-status-approved' : 'pageapprovals-status-not-approved' ).text();
 	$( '.page-approval-status' ).text( statusMessage );
 	mw.notify( message, { type: 'success' } );

--- a/src/EntryPoints/REST/ApprovePageApi.php
+++ b/src/EntryPoints/REST/ApprovePageApi.php
@@ -78,6 +78,7 @@ class ApprovePageApi extends SimpleHandler {
 		return $this->getResponseFactory()->createJson( [
 			'approvalTimestamp' => $state->approvalTimestamp,
 			'approver' => $this->getUserNameFromUserId( $state->approverId ),
+			'message' => ( new Message( 'pageapprovals-approved' ) )->plain()
 		] );
 	}
 

--- a/src/EntryPoints/REST/ApprovePageApi.php
+++ b/src/EntryPoints/REST/ApprovePageApi.php
@@ -94,7 +94,7 @@ class ApprovePageApi extends SimpleHandler {
 		return $this->getResponseFactory()->createHttpError(
 			403,
 			[
-				'message' => ( new Message( 'pageapprovals-authorization-failed' ) )->plain()
+				'message' => ( new Message( 'pageapprovals-approve-authorization-failed' ) )->plain()
 			]
 		);
 	}
@@ -103,7 +103,7 @@ class ApprovePageApi extends SimpleHandler {
 		return $this->getResponseFactory()->createHttpError(
 			404,
 			[
-				'message' => ( new Message( 'pageapprovals-invalid-page' ) )->plain()
+				'message' => ( new Message( 'pageapprovals-approve-invalid-page' ) )->plain()
 			]
 		);
 	}
@@ -112,7 +112,7 @@ class ApprovePageApi extends SimpleHandler {
 		return $this->getResponseFactory()->createHttpError(
 			409,
 			[
-				'message' => ( new Message( 'pageapprovals-outdated-revision' ) )->plain()
+				'message' => ( new Message( 'pageapprovals-approve-outdated-revision' ) )->plain()
 			]
 		);
 	}

--- a/src/EntryPoints/REST/ApprovePageApi.php
+++ b/src/EntryPoints/REST/ApprovePageApi.php
@@ -9,6 +9,7 @@ use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\User\UserIdentityLookup;
+use Message;
 use ProfessionalWiki\PageApprovals\Adapters\PageHtmlRetriever;
 use ProfessionalWiki\PageApprovals\Application\ApprovalAuthorizer;
 use ProfessionalWiki\PageApprovals\Application\ApprovalLog;
@@ -89,15 +90,30 @@ class ApprovePageApi extends SimpleHandler {
 	}
 
 	public function newAuthorizationFailedResponse(): Response {
-		return $this->getResponseFactory()->createHttpError( 403 );
+		return $this->getResponseFactory()->createHttpError(
+			403,
+			[
+				'message' => ( new Message( 'pageapprovals-authorization-failed' ) )->plain()
+			]
+		);
 	}
 
 	public function newInvalidPageResponse(): Response {
-		return $this->getResponseFactory()->createHttpError( 404 );
+		return $this->getResponseFactory()->createHttpError(
+			404,
+			[
+				'message' => ( new Message( 'pageapprovals-invalid-page' ) )->plain()
+			]
+		);
 	}
 
 	public function newOutdatedRevisionResponse(): Response {
-		return $this->getResponseFactory()->createHttpError( 409 );
+		return $this->getResponseFactory()->createHttpError(
+			409,
+			[
+				'message' => ( new Message( 'pageapprovals-outdated-revision' ) )->plain()
+			]
+		);
 	}
 
 	/**

--- a/src/EntryPoints/REST/UnapprovePageApi.php
+++ b/src/EntryPoints/REST/UnapprovePageApi.php
@@ -69,6 +69,7 @@ class UnapprovePageApi extends SimpleHandler {
 		return $this->getResponseFactory()->createJson( [
 			'approvalTimestamp' => $state->approvalTimestamp,
 			'approver' => $this->getUserNameFromUserId( $state->approverId ),
+			'message' => ( new Message( 'pageapprovals-unapproved' ) )->plain()
 		] );
 	}
 

--- a/src/EntryPoints/REST/UnapprovePageApi.php
+++ b/src/EntryPoints/REST/UnapprovePageApi.php
@@ -9,6 +9,7 @@ use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\User\UserIdentityLookup;
+use Message;
 use ProfessionalWiki\PageApprovals\Application\ApprovalAuthorizer;
 use ProfessionalWiki\PageApprovals\Application\ApprovalLog;
 use ProfessionalWiki\PageApprovals\Application\ApprovalState;
@@ -80,15 +81,30 @@ class UnapprovePageApi extends SimpleHandler {
 	}
 
 	public function newAuthorizationFailedResponse(): Response {
-		return $this->getResponseFactory()->createHttpError( 403 );
+		return $this->getResponseFactory()->createHttpError(
+			403,
+			[
+				'message' => ( new Message( 'pageapprovals-authorization-failed' ) )->plain()
+			]
+		);
 	}
 
 	public function newInvalidPageResponse(): Response {
-		return $this->getResponseFactory()->createHttpError( 404 );
+		return $this->getResponseFactory()->createHttpError(
+			404,
+			[
+				'message' => ( new Message( 'pageapprovals-invalid-page' ) )->plain()
+			]
+		);
 	}
 
 	public function newOutdatedRevisionResponse(): Response {
-		return $this->getResponseFactory()->createHttpError( 409 );
+		return $this->getResponseFactory()->createHttpError(
+			409,
+			[
+				'message' => ( new Message( 'pageapprovals-outdated-revision' ) )->plain()
+			]
+		);
 	}
 
 	/**

--- a/src/EntryPoints/REST/UnapprovePageApi.php
+++ b/src/EntryPoints/REST/UnapprovePageApi.php
@@ -85,7 +85,7 @@ class UnapprovePageApi extends SimpleHandler {
 		return $this->getResponseFactory()->createHttpError(
 			403,
 			[
-				'message' => ( new Message( 'pageapprovals-authorization-failed' ) )->plain()
+				'message' => ( new Message( 'pageapprovals-unapprove-authorization-failed' ) )->plain()
 			]
 		);
 	}
@@ -94,7 +94,7 @@ class UnapprovePageApi extends SimpleHandler {
 		return $this->getResponseFactory()->createHttpError(
 			404,
 			[
-				'message' => ( new Message( 'pageapprovals-invalid-page' ) )->plain()
+				'message' => ( new Message( 'pageapprovals-unapprove-invalid-page' ) )->plain()
 			]
 		);
 	}
@@ -103,7 +103,7 @@ class UnapprovePageApi extends SimpleHandler {
 		return $this->getResponseFactory()->createHttpError(
 			409,
 			[
-				'message' => ( new Message( 'pageapprovals-outdated-revision' ) )->plain()
+				'message' => ( new Message( 'pageapprovals-unapprove-outdated-revision' ) )->plain()
 			]
 		);
 	}

--- a/tests/EntryPoints/REST/ApprovePageApiTest.php
+++ b/tests/EntryPoints/REST/ApprovePageApiTest.php
@@ -44,13 +44,10 @@ class ApprovePageApiTest extends PageApprovalsIntegrationTest {
 		$state = $this->approvalLog->getApprovalState( $page->getId() );
 
 		$this->assertSame( 200, $response->getStatusCode() );
-		$this->assertSame(
-			[
-				'approvalTimestamp' => $state->approvalTimestamp,
-				'approver' => $user->getUser()->getName(),
-			],
-			json_decode( $response->getBody()->getContents(), true )
-		);
+
+		$json = json_decode( $response->getBody()->getContents(), true );
+		$this->assertSame( $state->approvalTimestamp, $json['approvalTimestamp'] );
+		$this->assertSame( $user->getUser()->getName(), $json['approver'] );
 	}
 
 	private function newApprovePageApi(): ApprovePageApi {

--- a/tests/EntryPoints/REST/UnapprovePageApiTest.php
+++ b/tests/EntryPoints/REST/UnapprovePageApiTest.php
@@ -43,13 +43,10 @@ class UnapprovePageApiTest extends PageApprovalsIntegrationTest {
 		$state = $this->approvalLog->getApprovalState( $page->getId() );
 
 		$this->assertSame( 200, $response->getStatusCode() );
-		$this->assertSame(
-			[
-				'approvalTimestamp' => $state->approvalTimestamp,
-				'approver' => $user->getUser()->getName(),
-			],
-			json_decode( $response->getBody()->getContents(), true )
-		);
+
+		$json = json_decode( $response->getBody()->getContents(), true );
+		$this->assertSame( $state->approvalTimestamp, $json['approvalTimestamp'] );
+		$this->assertSame( $user->getUser()->getName(), $json['approver'] );
 	}
 
 	private function newUnapprovePageApi(): UnapprovePageApi {


### PR DESCRIPTION
For #54

Mostly just generic placeholder messages. Feel free to make them more user-friendly.

Approve responses when the page is edited on another tab:

https://github.com/ProfessionalWiki/PageApprovals/assets/1428594/2fb83655-0034-4024-94ff-e13ed150f224

Unapprove responses when the page is edited on another tab:

https://github.com/ProfessionalWiki/PageApprovals/assets/1428594/4bd614b4-61f0-4e13-9b5f-b5caff53e919

Approve/Unapprove responses when the paeg is deleted on another tab:

https://github.com/ProfessionalWiki/PageApprovals/assets/1428594/116a566f-bf95-4d9b-a3e8-749e912e4e62

