### PR TITLE
Handle categories with spaces in DatabasePendingApprovalRetriever

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -71,6 +71,9 @@
     <InvalidReturnType>
       <code><![CDATA[string[]]]></code>
     </InvalidReturnType>
+    <MixedArgument>
+      <code><![CDATA[NS_CATEGORY]]></code>
+    </MixedArgument>
   </file>
   <file src="src/Adapters/PageHtmlRetriever.php">
     <PossiblyInvalidMethodCall>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -78,6 +78,9 @@
     </PossiblyInvalidMethodCall>
   </file>
   <file src="src/Application/UseCases/GetApproversWithCategories.php">
+    <MixedArgument>
+      <code><![CDATA[NS_CATEGORY]]></code>
+    </MixedArgument>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(int)$approver['userId']]]></code>
     </RedundantCastGivenDocblockType>
@@ -92,6 +95,11 @@
     <UnusedParam>
       <code><![CDATA[$approversCategories]]></code>
     </UnusedParam>
+  </file>
+  <file src="src/EntryPoints/Specials/SpecialPendingApprovals.php">
+    <MixedArgument>
+      <code><![CDATA[NS_CATEGORY]]></code>
+    </MixedArgument>
   </file>
   <file src="src/PageApprovals.php">
     <FalsableReturnStatement>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -20,6 +20,7 @@
     <MixedArgument>
       <code><![CDATA[$row->ac_categories]]></code>
       <code><![CDATA[$row->categories]]></code>
+      <code><![CDATA[NS_CATEGORY]]></code>
     </MixedArgument>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$approvers]]></code>

--- a/src/Adapters/AuthorityBasedApprovalAuthorizer.php
+++ b/src/Adapters/AuthorityBasedApprovalAuthorizer.php
@@ -34,7 +34,7 @@ class AuthorityBasedApprovalAuthorizer implements ApprovalAuthorizer {
 	 */
 	private function titleArrayObjectToStringArray( Iterator $titles ): array {
 		return array_map(
-			fn( Title $category ) => $category->getDBkey(), // TODO: verify handling of different category names
+			fn( Title $category ) => $category->getDBkey(),
 			iterator_to_array( $titles ),
 		);
 	}

--- a/src/Adapters/AuthorityBasedApprovalAuthorizer.php
+++ b/src/Adapters/AuthorityBasedApprovalAuthorizer.php
@@ -34,7 +34,7 @@ class AuthorityBasedApprovalAuthorizer implements ApprovalAuthorizer {
 	 */
 	private function titleArrayObjectToStringArray( Iterator $titles ): array {
 		return array_map(
-			fn( Title $category ) => $category->getText(), // TODO: verify handling of different category names
+			fn( Title $category ) => $category->getDBkey(), // TODO: verify handling of different category names
 			iterator_to_array( $titles ),
 		);
 	}

--- a/src/Adapters/DatabaseApproverRepository.php
+++ b/src/Adapters/DatabaseApproverRepository.php
@@ -84,7 +84,7 @@ class DatabaseApproverRepository implements ApproverRepository {
 
 	private function normalizeCategoryTitle( string $title ): string {
 		// TODO: Confirm database is not accessed, otherwise use TitleValue::tryNew()
-		return Title::newFromText( $title )?->getText() ?? '';
+		return Title::newFromText( $title, NS_CATEGORY )?->getDBkey() ?? '';
 	}
 
 	private function deserializeCategories( string $serializedCategories ): array {

--- a/src/Adapters/InMemoryApproverRepository.php
+++ b/src/Adapters/InMemoryApproverRepository.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\PageApprovals\Adapters;
 
 use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
+use Title;
 
 class InMemoryApproverRepository implements ApproverRepository {
 
@@ -31,7 +32,14 @@ class InMemoryApproverRepository implements ApproverRepository {
 	 * @param string[] $categoryNames
 	 */
 	public function setApproverCategories( int $userId, array $categoryNames ): void {
-		$this->approversCategories[$userId] = $categoryNames;
+		$this->approversCategories[$userId] = array_map(
+			fn( string $category ) => $this->normalizeCategoryTitle( $category ),
+			$categoryNames
+		);
+	}
+
+	private function normalizeCategoryTitle( string $title ): string {
+		return Title::newFromText( $title, NS_CATEGORY )?->getDBkey() ?? '';
 	}
 
 }

--- a/src/Application/PendingApproval.php
+++ b/src/Application/PendingApproval.php
@@ -9,7 +9,7 @@ use TitleValue;
 class PendingApproval {
 
 	/**
-	 * @param string[] $categories
+	 * @param string[] $categories The category DB keys.
 	 */
 	public function __construct(
 		public readonly TitleValue $title,

--- a/src/Application/UseCases/GetApproversWithCategories.php
+++ b/src/Application/UseCases/GetApproversWithCategories.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\PageApprovals\Application\UseCases;
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\PageApprovals\Application\Approver;
 use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
+use TitleValue;
 
 class GetApproversWithCategories {
 
@@ -28,11 +29,22 @@ class GetApproversWithCategories {
 			$approvers[] = new Approver(
 				username: $user->getName(),
 				userId: $approver['userId'],
-				categories: $approver['categories']
+				categories: $this->getCategoryTitlesFromDbKeys( $approver['categories'] )
 			);
 		}
 
 		return $approvers;
+	}
+
+	/**
+	 * @param string[] $categoryDbKeys
+	 * @return string[]
+	 */
+	private function getCategoryTitlesFromDbKeys( array $categoryDbKeys ): array {
+		return array_filter( array_map(
+			fn( string $dbKey ) => TitleValue::tryNew( NS_CATEGORY, $dbKey )?->getText(),
+			$categoryDbKeys
+		) );
 	}
 
 }

--- a/src/EntryPoints/Specials/SpecialPendingApprovals.php
+++ b/src/EntryPoints/Specials/SpecialPendingApprovals.php
@@ -7,6 +7,7 @@ use MediaWiki\Linker\LinkRenderer;
 use ProfessionalWiki\PageApprovals\Application\PendingApproval;
 use ProfessionalWiki\PageApprovals\Application\PendingApprovalRetriever;
 use SpecialPage;
+use TitleValue;
 
 class SpecialPendingApprovals extends SpecialPage {
 
@@ -78,10 +79,21 @@ class SpecialPendingApprovals extends SpecialPage {
 	private function createPendingApprovalRow( PendingApproval $pendingApproval ): string {
 		return $this->createTableRow( [
 			$this->linkRenderer->makeLink( $pendingApproval->title ),
-			implode( ', ', $pendingApproval->categories ),
+			implode( ', ', $this->getCategoryTitlesFromDbKeys( $pendingApproval->categories ) ),
 			$this->getLanguage()->userTimeAndDate( $pendingApproval->lastEditTimestamp, $this->getUser() ),
 			$pendingApproval->lastEditUserName
 		] );
+	}
+
+	/**
+	 * @param string[] $categoryDbKeys
+	 * @return string[]
+	 */
+	private function getCategoryTitlesFromDbKeys( array $categoryDbKeys ): array {
+		return array_filter( array_map(
+			fn( string $dbKey ) => TitleValue::tryNew( NS_CATEGORY, $dbKey )?->getText(),
+			$categoryDbKeys
+		) );
 	}
 
 }

--- a/tests/Adapters/DatabaseApproverRepositoryTest.php
+++ b/tests/Adapters/DatabaseApproverRepositoryTest.php
@@ -136,8 +136,8 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 				'Another category with spaces'
 			],
 			[
-				'Category with spaces',
-				'Another category with spaces'
+				'Category_with_spaces',
+				'Another_category_with_spaces'
 			],
 			'Categories with spaces'
 		];
@@ -150,7 +150,7 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 			],
 			[
 				'Subcategory',
-				'Category with underscores',
+				'Category_with_underscores',
 				'Category&with&ampersands'
 			],
 			'Categories with special characters'
@@ -189,9 +189,9 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 				' Both sides '
 			],
 			[
-				'Leading space',
-				'Trailing space',
-				'Both sides'
+				'Leading_space',
+				'Trailing_space',
+				'Both_sides'
 			],
 			'Category with leading/trailing spaces'
 		];
@@ -204,8 +204,8 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 				'foo bar'
 			],
 			[
-				'Foo Bar',
-				'Foo bar'
+				'Foo_Bar',
+				'Foo_bar'
 			],
 			'Category with case insensitive letters'
 		];

--- a/tests/Adapters/DatabasePendingApprovalRetrieverTest.php
+++ b/tests/Adapters/DatabasePendingApprovalRetrieverTest.php
@@ -131,7 +131,10 @@ class DatabasePendingApprovalRetrieverTest extends PageApprovalsIntegrationTest 
 
 		$this->assertCount( 1, $pendingApprovals );
 		$this->assertSame( $page->getTitle()->getText(), $pendingApprovals[0]->title->getText() );
-		$this->assertEqualsCanonicalizing( $pageCategories, $pendingApprovals[0]->categories );
+		$this->assertEqualsCanonicalizing(
+			[ 'Foo_Bar', 'Bar_baz' ],
+			$pendingApprovals[0]->categories
+		);
 	}
 
 }

--- a/tests/Adapters/DatabasePendingApprovalRetrieverTest.php
+++ b/tests/Adapters/DatabasePendingApprovalRetrieverTest.php
@@ -119,4 +119,19 @@ class DatabasePendingApprovalRetrieverTest extends PageApprovalsIntegrationTest 
 		);
 	}
 
+	public function testReturnsCategoriesWithSpaces(): void {
+		$approverId = 1;
+		$approverCategories = [ 'Foo Bar', 'Bar baz' ];
+		$this->approverRepository->setApproverCategories( $approverId, $approverCategories );
+
+		$pageCategories = [ 'Foo Bar', 'Bar baz' ];
+		$page = $this->createPage( false, $pageCategories );
+
+		$pendingApprovals = $this->retriever->getPendingApprovalsForApprover( $approverId );
+
+		$this->assertCount( 1, $pendingApprovals );
+		$this->assertSame( $page->getTitle()->getText(), $pendingApprovals[0]->title->getText() );
+		$this->assertEqualsCanonicalizing( $pageCategories, $pendingApprovals[0]->categories );
+	}
+
 }


### PR DESCRIPTION
Refs https://github.com/ProfessionalWiki/PageApprovals/pull/65#issuecomment-2200462843

Categories are saved using DB key (`Foo_bar`), and converted to human-readable titles (`Foo bar`) for display purposes.

----
Original description:

The code change was generated by Claude and slightly tweaked by me.

This probably isn't the best overall solution, though. Our category code is using the DB key and the human readable text in different places.

In `DatabasePendingApprovalRetriever`, the `cl_to` column contains the DB key (e.g. `Foo_bar`), whereas the `approver_config` table is storing categories in human readable form (e.g. `Foo bar`).

Ideally we stick to using one form, probably DB key for easier querying purposes. However, then we need to make sure we show the human readable form wherever we show categories from our own config.