### PR TITLE
Show message when user has no categories or no pending approvals

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -26,5 +26,6 @@
 	"pageapprovals-pending-approvals-categories": "Categories",
 	"pageapprovals-pending-approvals-last-edit-time": "Last Edited On",
 	"pageapprovals-pending-approvals-last-edit-by": "Last Edited By",
+	"pageapprovals-no-categories": "You are not authorized to approve pages.",
 	"pageapprovals-no-pending-approvals": "You have no pending approvals."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,5 +25,6 @@
 	"pageapprovals-pending-approvals-page": "Page",
 	"pageapprovals-pending-approvals-categories": "Categories",
 	"pageapprovals-pending-approvals-last-edit-time": "Last Edited On",
-	"pageapprovals-pending-approvals-last-edit-by": "Last Edited By"
+	"pageapprovals-pending-approvals-last-edit-by": "Last Edited By",
+	"pageapprovals-no-pending-approvals": "You have no pending approvals."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -25,5 +25,6 @@
 	"pageapprovals-pending-approvals-page": "Column on \"Special:PendingApprovals\" table",
 	"pageapprovals-pending-approvals-categories": "Column on \"Special:PendingApprovals\" table",
 	"pageapprovals-pending-approvals-last-edit-time": "Column on \"Special:PendingApprovals\" table",
-	"pageapprovals-pending-approvals-last-edit-by": "Column on \"Special:PendingApprovals\" table"
+	"pageapprovals-pending-approvals-last-edit-by": "Column on \"Special:PendingApprovals\" table",
+	"pageapprovals-no-pending-approvals": "Message on \"Special:PendingApprovals\""
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -26,5 +26,6 @@
 	"pageapprovals-pending-approvals-categories": "Column on \"Special:PendingApprovals\" table",
 	"pageapprovals-pending-approvals-last-edit-time": "Column on \"Special:PendingApprovals\" table",
 	"pageapprovals-pending-approvals-last-edit-by": "Column on \"Special:PendingApprovals\" table",
+	"pageapprovals-no-categories": "Message on \"Special:PendingApprovals\"",
 	"pageapprovals-no-pending-approvals": "Message on \"Special:PendingApprovals\""
 }

--- a/src/EntryPoints/Specials/SpecialPendingApprovals.php
+++ b/src/EntryPoints/Specials/SpecialPendingApprovals.php
@@ -4,6 +4,7 @@ namespace ProfessionalWiki\PageApprovals\EntryPoints\Specials;
 
 use Html;
 use MediaWiki\Linker\LinkRenderer;
+use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
 use ProfessionalWiki\PageApprovals\Application\PendingApproval;
 use ProfessionalWiki\PageApprovals\Application\PendingApprovalRetriever;
 use SpecialPage;
@@ -11,6 +12,7 @@ use SpecialPage;
 class SpecialPendingApprovals extends SpecialPage {
 
 	public function __construct(
+		private readonly ApproverRepository $approverRepository,
 		private readonly PendingApprovalRetriever $pendingApprovalRetriever,
 		private readonly LinkRenderer $linkRenderer
 	) {
@@ -21,6 +23,13 @@ class SpecialPendingApprovals extends SpecialPage {
 		$this->setHeaders();
 		$this->checkPermissions();
 		$this->checkReadOnly();
+
+		$categories = $this->approverRepository->getApproverCategories( $this->getUser()->getId() );
+
+		if ( $categories === [] ) {
+			$this->getOutput()->addWikiMsg( 'pageapprovals-no-categories' );
+			return;
+		}
 
 		$pendingApprovals = $this->pendingApprovalRetriever->getPendingApprovalsForApprover( $this->getUser()->getId() );
 

--- a/src/EntryPoints/Specials/SpecialPendingApprovals.php
+++ b/src/EntryPoints/Specials/SpecialPendingApprovals.php
@@ -22,11 +22,14 @@ class SpecialPendingApprovals extends SpecialPage {
 		$this->checkPermissions();
 		$this->checkReadOnly();
 
-		$this->getOutput()->addHTML(
-			$this->createPendingApprovalsTable(
-				$this->pendingApprovalRetriever->getPendingApprovalsForApprover( $this->getUser()->getId() )
-			)
-		);
+		$pendingApprovals = $this->pendingApprovalRetriever->getPendingApprovalsForApprover( $this->getUser()->getId() );
+
+		if ( $pendingApprovals === [] ) {
+			$this->getOutput()->addWikiMsg( 'pageapprovals-no-pending-approvals' );
+			return;
+		}
+
+		$this->getOutput()->addHTML( $this->createPendingApprovalsTable( $pendingApprovals ) );
 	}
 
 	/**

--- a/src/PageApprovals.php
+++ b/src/PageApprovals.php
@@ -112,6 +112,7 @@ class PageApprovals {
 
 	public static function newSpecialPendingApprovals(): SpecialPendingApprovals {
 		return new SpecialPendingApprovals(
+			self::getInstance()->getApproverRepository(),
 			self::getInstance()->newPendingApprovalRetriever(),
 			MediaWikiServices::getInstance()->getLinkRenderer()
 		);


### PR DESCRIPTION
For #23 

Instead of an empty table with only headers which looks broken.

No categories:
![Screenshot_20240704_122131](https://github.com/ProfessionalWiki/PageApprovals/assets/1428594/453a830d-de02-47fb-a545-b36b56cb3248)

No pending approvals:
![Screenshot_20240704_120727](https://github.com/ProfessionalWiki/PageApprovals/assets/1428594/6380a2a0-2e40-4a85-9610-ff85b057734c)