### PR TITLE
Add approve button as an indicator

### DIFF
--- a/resources/PageApprovals.css
+++ b/resources/PageApprovals.css
@@ -1,7 +1,4 @@
 .page-approval-container {
-	position: absolute;
-	top: -55px;
-	right: 0;
 	z-index: 1;
 	display: flex;
 	align-items: center;

--- a/src/Presentation/OutputPageUiPresenter.php
+++ b/src/Presentation/OutputPageUiPresenter.php
@@ -20,8 +20,8 @@ class OutputPageUiPresenter {
 			return;
 		}
 
-		$this->out->addHTML(
-			PageApprovals::getInstance()->getTemplateParser()->processTemplate(
+		$this->out->setIndicators( [
+			'page-approvals' => PageApprovals::getInstance()->getTemplateParser()->processTemplate(
 				'PageApprovalStatus',
 				[
 					'isPageApproved' => $arguments->pageIsApproved,
@@ -35,7 +35,7 @@ class OutputPageUiPresenter {
 					'approvalTimestamp' => $arguments->approvalTimestamp
 				]
 			)
-		);
+		] );
 
 		$this->out->addModuleStyles( 'ext.pageApprovals.styles' );
 		$this->out->addModules( 'ext.pageApprovals.scripts' );

--- a/tests/EntryPoints/PageApprovalsHooksTest.php
+++ b/tests/EntryPoints/PageApprovalsHooksTest.php
@@ -52,9 +52,9 @@ class PageApprovalsHooksTest extends PageApprovalsIntegrationTest {
 
 		PageApprovalsHooks::onOutputPageBeforeHTML( $this->out );
 
-		$this->assertStringContainsString(
-			'page-approval-container',
-			$this->out->getHTML(),
+		$this->assertArrayHasKey(
+			'page-approvals',
+			$this->out->getIndicators(),
 			'The page approval status should be displayed with a matching category.'
 		);
 	}


### PR DESCRIPTION
For #89 

I forgot that the indicators system is the right way of adding "page status" things around the page header.

This way it is up to the skin to position it correctly.

Vector:

https://github.com/user-attachments/assets/1640fe61-cb94-4f4a-ab4a-712c6f2c1ba9

Vector 2022:

https://github.com/user-attachments/assets/b72621bf-0893-46c1-a718-de6ae1b487e4

Chameleon:

https://github.com/user-attachments/assets/f2672521-e19b-4567-bfec-f684ceabffb4

The Chameleon layout is slightly wrong, but that has more to do with how Chameleon positions the indicators next to the title. We can just add a fix on the wiki instead of adding a Chameleon-specific fix here (which might not even work when there are Chameleon customizations).
