### PR TITLE
Refactor approver category name normalization

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -62,6 +62,7 @@
       <code><![CDATA[$row->categories]]></code>
       <code><![CDATA[$row->page_title]]></code>
       <code><![CDATA[NS_CATEGORY]]></code>
+      <code><![CDATA[NS_CATEGORY]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$name]]></code>
@@ -100,11 +101,6 @@
     <UnusedParam>
       <code><![CDATA[$approversCategories]]></code>
     </UnusedParam>
-  </file>
-  <file src="src/EntryPoints/Specials/SpecialPendingApprovals.php">
-    <MixedArgument>
-      <code><![CDATA[NS_CATEGORY]]></code>
-    </MixedArgument>
   </file>
   <file src="src/PageApprovals.php">
     <FalsableReturnStatement>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -22,6 +22,7 @@
       <code><![CDATA[$row->categories]]></code>
       <code><![CDATA[$row->categories]]></code>
       <code><![CDATA[NS_CATEGORY]]></code>
+      <code><![CDATA[NS_CATEGORY]]></code>
     </MixedArgument>
     <MixedReturnTypeCoercion>
       <code><![CDATA[$approvers]]></code>
@@ -60,6 +61,7 @@
     <MixedArgument>
       <code><![CDATA[$row->categories]]></code>
       <code><![CDATA[$row->page_title]]></code>
+      <code><![CDATA[NS_CATEGORY]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$name]]></code>
@@ -71,11 +73,6 @@
       <code><![CDATA[$row->rev_actor]]></code>
       <code><![CDATA[$row->rev_timestamp]]></code>
     </PossiblyInvalidPropertyFetch>
-  </file>
-  <file src="src/Adapters/InMemoryApproverRepository.php">
-    <MixedArgument>
-      <code><![CDATA[NS_CATEGORY]]></code>
-    </MixedArgument>
   </file>
   <file src="src/Adapters/PageHtmlRetriever.php">
     <PossiblyInvalidMethodCall>

--- a/src/Adapters/AuthorityBasedApprovalAuthorizer.php
+++ b/src/Adapters/AuthorityBasedApprovalAuthorizer.php
@@ -34,7 +34,7 @@ class AuthorityBasedApprovalAuthorizer implements ApprovalAuthorizer {
 	 */
 	private function titleArrayObjectToStringArray( Iterator $titles ): array {
 		return array_map(
-			fn( Title $category ) => $category->getDBkey(),
+			fn( Title $category ) => $category->getText(),
 			iterator_to_array( $titles ),
 		);
 	}

--- a/src/Adapters/DatabaseApproverRepository.php
+++ b/src/Adapters/DatabaseApproverRepository.php
@@ -105,7 +105,6 @@ class DatabaseApproverRepository implements ApproverRepository {
 	}
 
 	private function normalizeCategoryTitle( string $title ): string {
-		// TODO: Confirm database is not accessed, otherwise use TitleValue::tryNew()
 		return Title::newFromText( $title, NS_CATEGORY )?->getDBkey() ?? '';
 	}
 

--- a/src/Adapters/DatabaseApproverRepository.php
+++ b/src/Adapters/DatabaseApproverRepository.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\PageApprovals\Adapters;
 
 use ProfessionalWiki\PageApprovals\Application\ApproverRepository;
 use Title;
+use TitleValue;
 use Wikimedia\Rdbms\IDatabase;
 
 class DatabaseApproverRepository implements ApproverRepository {
@@ -109,7 +110,20 @@ class DatabaseApproverRepository implements ApproverRepository {
 	}
 
 	private function deserializeCategories( string $serializedCategories ): array {
-		return $serializedCategories === '' ? [] : explode( '|', $serializedCategories );
+		return $serializedCategories === ''
+			? []
+			: $this->getCategoryTitlesFromDbKeys( explode( '|', $serializedCategories ) );
+	}
+
+	/**
+	 * @param string[] $categoryDbKeys
+	 * @return string[]
+	 */
+	private function getCategoryTitlesFromDbKeys( array $categoryDbKeys ): array {
+		return array_filter( array_map(
+			fn( string $dbKey ) => TitleValue::tryNew( NS_CATEGORY, $dbKey )?->getText() ?? '',
+			$categoryDbKeys
+		) );
 	}
 
 }

--- a/src/Adapters/DatabaseApproverRepository.php
+++ b/src/Adapters/DatabaseApproverRepository.php
@@ -111,14 +111,14 @@ class DatabaseApproverRepository implements ApproverRepository {
 	private function deserializeCategories( string $serializedCategories ): array {
 		return $serializedCategories === ''
 			? []
-			: $this->getCategoryTitlesFromDbKeys( explode( '|', $serializedCategories ) );
+			: $this->getCategoryNamesFromDbKeys( explode( '|', $serializedCategories ) );
 	}
 
 	/**
 	 * @param string[] $categoryDbKeys
 	 * @return string[]
 	 */
-	private function getCategoryTitlesFromDbKeys( array $categoryDbKeys ): array {
+	private function getCategoryNamesFromDbKeys( array $categoryDbKeys ): array {
 		return array_filter( array_map(
 			fn( string $dbKey ) => TitleValue::tryNew( NS_CATEGORY, $dbKey )?->getText() ?? '',
 			$categoryDbKeys

--- a/src/Adapters/DatabasePendingApprovalRetriever.php
+++ b/src/Adapters/DatabasePendingApprovalRetriever.php
@@ -58,7 +58,7 @@ class DatabasePendingApprovalRetriever implements PendingApprovalRetriever {
 				'latest_approval.al_timestamp'
 			],
 			[
-				'cl_to' => $categories,
+				'cl_to' => $this->normalizeCategoryTitles( $categories ),
 				$this->db->makeList(
 					[
 						'latest_approval.al_is_approved' => 0,
@@ -108,6 +108,17 @@ class DatabasePendingApprovalRetriever implements PendingApprovalRetriever {
 				'a.al_timestamp = latest.max_timestamp'
 			],
 			__METHOD__
+		);
+	}
+
+	/**
+	 * @param string[] $categories
+	 * @return string[]
+	 */
+	private function normalizeCategoryTitles( array $categories ): array {
+		return array_map(
+			fn( string $category ) => TitleValue::tryNew( NS_CATEGORY, $category )?->getDBkey() ?? '',
+			$categories
 		);
 	}
 

--- a/src/Adapters/DatabasePendingApprovalRetriever.php
+++ b/src/Adapters/DatabasePendingApprovalRetriever.php
@@ -130,7 +130,7 @@ class DatabasePendingApprovalRetriever implements PendingApprovalRetriever {
 
 		foreach ( $res as $row ) {
 			$title = new TitleValue( (int)$row->page_namespace, $row->page_title );
-			$categories = explode( ',', $row->categories );
+			$categories = $this->getCategoryTitlesFromDbKeys( explode( ',', $row->categories ) );
 			$lastEditUserName = $this->getUserNameFromActor( (int)$row->rev_actor );
 
 			$pendingApprovals[] = new PendingApproval(
@@ -142,6 +142,17 @@ class DatabasePendingApprovalRetriever implements PendingApprovalRetriever {
 		}
 
 		return $pendingApprovals;
+	}
+
+	/**
+	 * @param string[] $categoryDbKeys
+	 * @return string[]
+	 */
+	private function getCategoryTitlesFromDbKeys( array $categoryDbKeys ): array {
+		return array_filter( array_map(
+			fn( string $dbKey ) => TitleValue::tryNew( NS_CATEGORY, $dbKey )?->getText() ?? '',
+			$categoryDbKeys
+		) );
 	}
 
 	private function getUserNameFromActor( int $actorId ): string {

--- a/src/Adapters/DatabasePendingApprovalRetriever.php
+++ b/src/Adapters/DatabasePendingApprovalRetriever.php
@@ -130,7 +130,7 @@ class DatabasePendingApprovalRetriever implements PendingApprovalRetriever {
 
 		foreach ( $res as $row ) {
 			$title = new TitleValue( (int)$row->page_namespace, $row->page_title );
-			$categories = $this->getCategoryTitlesFromDbKeys( explode( ',', $row->categories ) );
+			$categories = $this->getCategoryNamesFromDbKeys( explode( ',', $row->categories ) );
 			$lastEditUserName = $this->getUserNameFromActor( (int)$row->rev_actor );
 
 			$pendingApprovals[] = new PendingApproval(
@@ -148,7 +148,7 @@ class DatabasePendingApprovalRetriever implements PendingApprovalRetriever {
 	 * @param string[] $categoryDbKeys
 	 * @return string[]
 	 */
-	private function getCategoryTitlesFromDbKeys( array $categoryDbKeys ): array {
+	private function getCategoryNamesFromDbKeys( array $categoryDbKeys ): array {
 		return array_filter( array_map(
 			fn( string $dbKey ) => TitleValue::tryNew( NS_CATEGORY, $dbKey )?->getText() ?? '',
 			$categoryDbKeys

--- a/src/Adapters/InMemoryApproverRepository.php
+++ b/src/Adapters/InMemoryApproverRepository.php
@@ -41,13 +41,9 @@ class InMemoryApproverRepository implements ApproverRepository {
 	 */
 	public function setApproverCategories( int $userId, array $categoryNames ): void {
 		$this->categoriesPerUser[$userId] = array_map(
-			fn( string $category ) => $this->normalizeCategoryTitle( $category ),
+			fn( string $category ) => $category,
 			$categoryNames
 		);
-	}
-
-	private function normalizeCategoryTitle( string $title ): string {
-		return Title::newFromText( $title, NS_CATEGORY )?->getDBkey() ?? '';
 	}
 
 }

--- a/src/Application/PendingApproval.php
+++ b/src/Application/PendingApproval.php
@@ -9,7 +9,7 @@ use TitleValue;
 class PendingApproval {
 
 	/**
-	 * @param string[] $categories The category DB keys.
+	 * @param string[] $categories
 	 */
 	public function __construct(
 		public readonly TitleValue $title,

--- a/src/Application/UseCases/GetApproversWithCategories.php
+++ b/src/Application/UseCases/GetApproversWithCategories.php
@@ -29,7 +29,7 @@ class GetApproversWithCategories {
 			$approvers[] = new Approver(
 				username: $user->getName(),
 				userId: $approver['userId'],
-				categories: $this->getCategoryTitlesFromDbKeys( $approver['categories'] )
+				categories: $this->getCategoryNamesFromDbKeys( $approver['categories'] )
 			);
 		}
 
@@ -40,7 +40,7 @@ class GetApproversWithCategories {
 	 * @param string[] $categoryDbKeys
 	 * @return string[]
 	 */
-	private function getCategoryTitlesFromDbKeys( array $categoryDbKeys ): array {
+	private function getCategoryNamesFromDbKeys( array $categoryDbKeys ): array {
 		return array_filter( array_map(
 			fn( string $dbKey ) => TitleValue::tryNew( NS_CATEGORY, $dbKey )?->getText(),
 			$categoryDbKeys

--- a/src/EntryPoints/Specials/SpecialPendingApprovals.php
+++ b/src/EntryPoints/Specials/SpecialPendingApprovals.php
@@ -84,7 +84,7 @@ HTML;
 			"\n",
 			[
 				Html::rawElement( 'td', [], $this->linkRenderer->makeLink( $pendingApproval->title ) ),
-				Html::element( 'td', [], implode( ', ', $this->getCategoryTitlesFromDbKeys( $pendingApproval->categories ) ) ),
+				Html::element( 'td', [], implode( ', ', $pendingApproval->categories ) ),
 				Html::element(
 					'td',
 					[ 'data-sort-value' => $pendingApproval->lastEditTimestamp ],
@@ -95,17 +95,6 @@ HTML;
 		);
 
 		return "<tr>$cells</tr>";
-	}
-
-	/**
-	 * @param string[] $categoryDbKeys
-	 * @return string[]
-	 */
-	private function getCategoryTitlesFromDbKeys( array $categoryDbKeys ): array {
-		return array_filter( array_map(
-			fn( string $dbKey ) => TitleValue::tryNew( NS_CATEGORY, $dbKey )?->getText(),
-			$categoryDbKeys
-		) );
 	}
 
 }

--- a/tests/Adapters/AuthorityBasedApprovalAuthorizerTest.php
+++ b/tests/Adapters/AuthorityBasedApprovalAuthorizerTest.php
@@ -59,4 +59,11 @@ class AuthorityBasedApprovalAuthorizerTest extends PageApprovalsIntegrationTest 
 		$this->assertFalse( $this->approvalAuthorizer->canApprove( $page ) );
 	}
 
+	public function testCanApproveWhenCategoryContainsSpaces(): void {
+		$page = $this->createPageWithCategories( [ 'Test - Category' ] );
+		$this->approverRepository->setApproverCategories( $this->user->getId(), [ 'Test - Category' ] );
+
+		$this->assertTrue( $this->approvalAuthorizer->canApprove( $page ) );
+	}
+
 }

--- a/tests/Adapters/DatabaseApproverRepositoryTest.php
+++ b/tests/Adapters/DatabaseApproverRepositoryTest.php
@@ -149,8 +149,8 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 				'Another category with spaces'
 			],
 			[
-				'Category_with_spaces',
-				'Another_category_with_spaces'
+				'Category with spaces',
+				'Another category with spaces'
 			],
 			'Categories with spaces'
 		];
@@ -163,7 +163,7 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 			],
 			[
 				'Subcategory',
-				'Category_with_underscores',
+				'Category with underscores',
 				'Category&with&ampersands'
 			],
 			'Categories with special characters'
@@ -202,9 +202,9 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 				' Both sides '
 			],
 			[
-				'Leading_space',
-				'Trailing_space',
-				'Both_sides'
+				'Leading space',
+				'Trailing space',
+				'Both sides'
 			],
 			'Category with leading/trailing spaces'
 		];
@@ -217,8 +217,8 @@ class DatabaseApproverRepositoryTest extends MediaWikiIntegrationTestCase {
 				'foo bar'
 			],
 			[
-				'Foo_Bar',
-				'Foo_bar'
+				'Foo Bar',
+				'Foo bar'
 			],
 			'Category with case insensitive letters'
 		];

--- a/tests/Adapters/DatabasePendingApprovalRetrieverTest.php
+++ b/tests/Adapters/DatabasePendingApprovalRetrieverTest.php
@@ -155,7 +155,7 @@ class DatabasePendingApprovalRetrieverTest extends PageApprovalsIntegrationTest 
 		$this->assertCount( 1, $pendingApprovals );
 		$this->assertSame( $page->getTitle()->getText(), $pendingApprovals[0]->title->getText() );
 		$this->assertEqualsCanonicalizing(
-			[ 'Foo_Bar', 'Bar_baz' ],
+			[ 'Foo Bar', 'Bar baz' ],
 			$pendingApprovals[0]->categories
 		);
 	}

--- a/tests/EntryPoints/Specials/SpecialManageApproversTest.php
+++ b/tests/EntryPoints/Specials/SpecialManageApproversTest.php
@@ -153,7 +153,7 @@ class SpecialManageApproversTest extends SpecialPageTestBase {
 		);
 	}
 
-		public function testAddCategoryWithSpaces(): void {
+	public function testAddCategoryWithSpaces(): void {
 		$user = self::getTestUser()->getUser();
 
 		$this->post(
@@ -165,7 +165,7 @@ class SpecialManageApproversTest extends SpecialPageTestBase {
 		);
 
 		$this->assertSame(
-			[ 'Test_-_Category' ],
+			[ 'Test - Category' ],
 			$this->approverRepository->getApproverCategories( $user->getId() )
 		);
 	}

--- a/tests/EntryPoints/Specials/SpecialManageApproversTest.php
+++ b/tests/EntryPoints/Specials/SpecialManageApproversTest.php
@@ -153,4 +153,43 @@ class SpecialManageApproversTest extends SpecialPageTestBase {
 		);
 	}
 
+		public function testAddCategoryWithSpaces(): void {
+		$user = self::getTestUser()->getUser();
+
+		$this->post(
+			request: [
+				'action' => 'add',
+				'username' => $user->getName(),
+				'category' => 'Test - Category'
+			]
+		);
+
+		$this->assertSame(
+			[ 'Test_-_Category' ],
+			$this->approverRepository->getApproverCategories( $user->getId() )
+		);
+	}
+
+	public function testRemoveCategoryWithSpaces(): void {
+		$user = self::getTestUser()->getUser();
+
+		$this->approverRepository->setApproverCategories(
+			$user->getId(),
+			[ 'Test - Category' ]
+		);
+
+		$this->post(
+			request: [
+				'action' => 'delete',
+				'username' => $user->getName(),
+				'category' => 'Test - Category'
+			]
+		);
+
+		$this->assertSame(
+			[],
+			$this->approverRepository->getApproverCategories( $user->getId() )
+		);
+	}
+
 }


### PR DESCRIPTION
High level changes:
* Use normalized category names (DBkey) only in persistence classes.
* Other classes work with the human-readable name 

Specific issues addressed:
* Special:ManageApprovers: removing categories with spaces
* On page: show indicator when category contains spaces