### PR TITLE
Hide row for zero categories

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -101,6 +101,11 @@ parameters:
 			path: src/EntryPoints/Specials/SpecialManageApprovers.php
 
 		-
+			message: "#^Cannot call method getName\\(\\) on User\\|null\\.$#"
+			count: 1
+			path: src/EntryPoints/Specials/SpecialManageApprovers.php
+
+		-
 			message: "#^Parameter \\#1 \\$php of static method LightnCandy\\\\LightnCandy\\:\\:prepare\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/EntryPoints/Specials/SpecialManageApprovers.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="src/Adapters/AuthorityBasedApprovalAuthorizer.php">
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$page->getCategories()]]></code>
@@ -91,6 +91,7 @@
   <file src="src/EntryPoints/Specials/SpecialManageApprovers.php">
     <PossiblyNullReference>
       <code><![CDATA[getId]]></code>
+      <code><![CDATA[getName]]></code>
     </PossiblyNullReference>
     <UndefinedClass>
       <code><![CDATA[LightnCandy]]></code>

--- a/src/EntryPoints/Specials/SpecialManageApprovers.php
+++ b/src/EntryPoints/Specials/SpecialManageApprovers.php
@@ -33,8 +33,6 @@ class SpecialManageApprovers extends SpecialPage {
 		$request = $this->getRequest();
 		if ( $request->wasPosted() ) {
 			$this->handlePostRequest( $request );
-			$this->getOutput()->redirect( $this->getPageTitle()->getLocalURL() );
-			return;
 		}
 
 		$approversWithCategories = new GetApproversWithCategories( $this->approverRepository );
@@ -109,10 +107,14 @@ class SpecialManageApprovers extends SpecialPage {
 	 * @return array<string, mixed>
 	 */
 	private function approverToViewModel( Approver $approver ): array {
+		$request = $this->getRequest();
+		$showCategories = $request->wasPosted() && $request->getText( 'username' ) === $approver->username;
+
 		return [
 			'username' => $approver->username,
 			'userId' => $approver->userId,
-			'categories' => $approver->categories
+			'categories' => $approver->categories,
+			'showCategories' => !empty( $approver->categories ) || $showCategories
 		];
 	}
 

--- a/src/EntryPoints/Specials/SpecialManageApprovers.php
+++ b/src/EntryPoints/Specials/SpecialManageApprovers.php
@@ -128,7 +128,7 @@ class SpecialManageApprovers extends SpecialPage {
 		return [
 			'username' => $approver->username,
 			'userId' => $approver->userId,
-			'categories' => $approver->categories,
+			'categories' => $approver->categories
 		];
 	}
 

--- a/src/EntryPoints/Specials/SpecialManageApprovers.php
+++ b/src/EntryPoints/Specials/SpecialManageApprovers.php
@@ -107,14 +107,19 @@ class SpecialManageApprovers extends SpecialPage {
 	 * @return array<string, mixed>
 	 */
 	private function approverToViewModel( Approver $approver ): array {
-		$request = $this->getRequest();
-		$showCategories = $request->wasPosted() && $request->getText( 'username' ) === $approver->username;
+		$showCategories = true;
+
+		if ( empty( $approver->categories ) ) {
+			$request = $this->getRequest();
+			$user = $this->userFactory->newFromName( $request->getText( 'username' ) );
+			$showCategories = $request->wasPosted() && $user->getName() === $approver->username;
+		}
 
 		return [
 			'username' => $approver->username,
 			'userId' => $approver->userId,
 			'categories' => $approver->categories,
-			'showCategories' => !empty( $approver->categories ) || $showCategories
+			'showCategories' => $showCategories
 		];
 	}
 

--- a/src/EntryPoints/Specials/SpecialManageApprovers.php
+++ b/src/EntryPoints/Specials/SpecialManageApprovers.php
@@ -67,14 +67,12 @@ class SpecialManageApprovers extends SpecialPage {
 		$currentCategories = $this->approverRepository->getApproverCategories( $userId );
 
 		switch ( $action ) {
+			case 'add-approver':
 			case 'add':
 				$currentCategories[] = $category;
 				break;
 			case 'delete':
 				$currentCategories = array_filter( $currentCategories, fn( string $cat ) => $cat !== $category );
-				break;
-			case 'add-approver':
-				$currentCategories = [];
 				break;
 			default:
 				return;
@@ -118,7 +116,12 @@ class SpecialManageApprovers extends SpecialPage {
 	 * @return array<array<string, mixed>>
 	 */
 	private function approversToViewModel( array $approvers ): array {
-		return array_map( fn( Approver $approver ) => $this->approverToViewModel( $approver ), $approvers );
+		return array_values(
+			array_map(
+				fn( Approver $approver ) => $this->approverToViewModel( $approver ),
+				$approvers
+			)
+		);
 	}
 
 	/**

--- a/templates/ManageApprovers.mustache
+++ b/templates/ManageApprovers.mustache
@@ -15,28 +15,27 @@
 		</thead>
 		<tbody>
 		{{#approvers}}
-			{{#showCategories}}
-				<tr>
-					<td>{{username}}</td>
-					<td>
-						{{#categories}}
-							<div class="category-entry">
-								<span class="category-name">{{.}}</span>
-								<form method="POST" action="" class="category-row">
-									<input type="hidden" name="username" value="{{username}}">
-									<input type="hidden" name="category" value="{{.}}">
-									<button class="approval-delete-btn" type="submit" name="action" value="delete">Delete</button>
-								</form>
-							</div>
-						{{/categories}}
-						<form method="POST" action="" class="add-category-form">
-							<input type="text" name="category" placeholder="New Category" required>
-							<input type="hidden" name="username" value="{{username}}">
-							<button class="add-button" type="submit" name="action" value="add">Add</button>
-						</form>
-					</td>
-				</tr>
-			{{/showCategories}}
+			<tr>
+				<td>{{username}}</td>
+				<td>
+					{{#categories}}
+						<div class="category-entry">
+							<span class="category-name">{{.}}</span>
+							<form method="POST" action="" class="category-row">
+								<input type="hidden" name="username" value="{{username}}">
+								<input type="hidden" name="category" value="{{.}}">
+								<button class="approval-delete-btn" type="submit" name="action" value="delete">Delete
+								</button>
+							</form>
+						</div>
+					{{/categories}}
+					<form method="POST" action="" class="add-category-form">
+						<input type="text" name="category" placeholder="New Category" required>
+						<input type="hidden" name="username" value="{{username}}">
+						<button class="add-button" type="submit" name="action" value="add">Add</button>
+					</form>
+				</td>
+			</tr>
 		{{/approvers}}
 		</tbody>
 	</table>

--- a/templates/ManageApprovers.mustache
+++ b/templates/ManageApprovers.mustache
@@ -15,28 +15,34 @@
 		</thead>
 		<tbody>
 		{{#approvers}}
-			<tr>
-				<td>{{username}}</td>
-				<td>
-					{{#categories}}
-						<div class="category-entry">
-							<span class="category-name">{{.}}</span>
-							<form method="POST" action="" class="category-row">
-								<input type="hidden" name="username" value="{{username}}">
-								<input type="hidden" name="category" value="{{.}}">
-								<button class="approval-delete-btn" type="submit" name="action" value="delete">Delete
-								</button>
-							</form>
-						</div>
-					{{/categories}}
-					<form method="POST" action="" class="add-category-form">
-						<input type="text" name="category" placeholder="New Category" required>
-						<input type="hidden" name="username" value="{{username}}">
-						<button class="add-button" type="submit" name="action" value="add">Add</button>
-					</form>
-				</td>
-			</tr>
+			{{#showCategories}}
+				<tr>
+					<td>{{username}}</td>
+					<td>
+						{{#categories}}
+							<div class="category-entry">
+								<span class="category-name">{{.}}</span>
+								<form method="POST" action="" class="category-row">
+									<input type="hidden" name="username" value="{{username}}">
+									<input type="hidden" name="category" value="{{.}}">
+									<button class="approval-delete-btn" type="submit" name="action" value="delete">Delete</button>
+								</form>
+							</div>
+						{{/categories}}
+						<form method="POST" action="" class="add-category-form">
+							<input type="text" name="category" placeholder="New Category" required>
+							<input type="hidden" name="username" value="{{username}}">
+							<button class="add-button" type="submit" name="action" value="add">Add</button>
+						</form>
+					</td>
+				</tr>
+			{{/showCategories}}
 		{{/approvers}}
 		</tbody>
 	</table>
 </div>
+<script>
+	if( window.history.replaceState ) {
+		window.history.replaceState( null, null, window.location.href );
+	}
+</script>

--- a/tests/EntryPoints/Specials/SpecialManageApproversTest.php
+++ b/tests/EntryPoints/Specials/SpecialManageApproversTest.php
@@ -20,6 +20,7 @@ class SpecialManageApproversTest extends SpecialPageTestBase {
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->tablesUsed[] = 'approver_config';
 		$this->approverRepository = PageApprovals::getInstance()->getApproverRepository();
 	}
 

--- a/tests/EntryPoints/Specials/SpecialManageApproversTest.php
+++ b/tests/EntryPoints/Specials/SpecialManageApproversTest.php
@@ -55,7 +55,9 @@ class SpecialManageApproversTest extends SpecialPageTestBase {
 	}
 
 	public function testAddApproverAction(): void {
-		$username = self::getTestUser()->getUser()->getName();
+		$testUser = self::getTestUser()->getUser();
+		$username = $testUser->getName();
+		$userId = $testUser->getId();
 
 		$this->post(
 			request: [
@@ -64,18 +66,13 @@ class SpecialManageApproversTest extends SpecialPageTestBase {
 			]
 		);
 
-		$output = $this->viewPage();
+		$approvers = $this->approverRepository->getApproversWithCategories();
 
-		$this->assertStringContainsString(
-			$username,
-			$output,
-			'Expected HTML output to contain the new approver username'
-		);
-		$this->assertStringNotContainsString(
-			'<div class="category-entry">',
-			$output,
-			'New approver should have no categories'
-		);
+		$approver = array_filter( $approvers, fn( $approver ) => $approver['userId'] === $userId );
+		$newApprover = reset( $approver );
+
+		$this->assertNotNull( $newApprover, 'New approver should be added' );
+		$this->assertSame( [], $newApprover['categories'], 'New approver should have no categories' );
 	}
 
 	private function post( array $request ): void {


### PR DESCRIPTION
For: https://github.com/ProfessionalWiki/PageApprovals/issues/101

Although I didn't make many changes, there is mainly just one function for filtering approvers, but other approaches came to my mind. 

1- It might be cleaner to have separate Endpoints for Add/Delete Categories. If we do that, we will either have to refresh the page or manipulate the HTML with JS, which is also not very clean. 

2- Another approach might be to Delete the category from DB, but when to delete it also requires building some logic. 

3- We can also keep the approver name only on the FE and never send it to the BE unless it has categories, but then we will also have to manipulate HTML using JS, which is also not the cleanest way.


Updated Test:

https://github.com/user-attachments/assets/50822668-b317-4ec6-ad1a-84207e0a1329


I request reviewers to test the UI if possible. Although I tested thoroughly but maybe I missed something. There is one case that it doesn't cover, which I mentioned here:

https://github.com/ProfessionalWiki/PageApprovals/issues/101#issuecomment-2290185591