### PR TITLE
Ignore SMW ids when evaluating approval state

### DIFF
--- a/src/Application/UseCases/EvaluateApprovalState.php
+++ b/src/Application/UseCases/EvaluateApprovalState.php
@@ -16,11 +16,19 @@ class EvaluateApprovalState {
 	}
 
 	public function evaluate( int $pageId, string $currentPageHtml ): void {
-		if ( $currentPageHtml !== $this->getApprovedHtmlForPage( $pageId )
+		if ( !$this->htmlIsTheSame( $currentPageHtml, $this->getApprovedHtmlForPage( $pageId ) ?? '' )
 			&& $this->approvalLog->getApprovalState( $pageId )?->isApproved === true
 		) {
 			$this->unapprovePage( $pageId );
 		}
+	}
+
+	private function htmlIsTheSame( string $html1, string $html2 ): bool {
+		return $this->normalizeHtml( $html1 ) === $this->normalizeHtml( $html2 );
+	}
+
+	private function normalizeHtml( string $html ): string {
+		return preg_replace( '/id="smw-[^"]+"/', '', $html ) ?? '';
 	}
 
 	private function getApprovedHtmlForPage( int $pageId ): ?string {

--- a/tests/Application/UseCases/EvaluateApprovalStateTest.php
+++ b/tests/Application/UseCases/EvaluateApprovalStateTest.php
@@ -82,4 +82,20 @@ class EvaluateApprovalStateTest extends TestCase {
 		$this->assertNull( $approvalLog->getApprovalState( self::PAGE_ID ) );
 	}
 
+	public function testSmwIdsAreIgnored(): void {
+		$approvalLog = $this->newApprovalLogWithApprovedPage();
+
+		$htmlRepo = new InMemoryHtmlRepository();
+		$htmlRepo->saveApprovedHtml( self::PAGE_ID, '<div id="smw-123">content</div><div id="not-smw">content</div>' );
+
+		$action = new EvaluateApprovalState(
+			htmlRepository: $htmlRepo,
+			approvalLog: $approvalLog
+		);
+
+		$action->evaluate( self::PAGE_ID, '<div id="smw-456">content</div><div id="not-smw">content</div>' );
+
+		$this->assertTrue( $approvalLog->getApprovalState( self::PAGE_ID )->isApproved );
+	}
+
 }


### PR DESCRIPTION
Semantic Results Format Datatables contain ids that change on page load. This causes approval state evaluation to fail because the saved id is different.

This PR just addresses the SRF id issue.

----

Thoughts:
* Should we perhaps ignore all ids (and maybe classes)? We haven't run into other issues yet, but the idea is there could be future issues here and it could be argued ids/classes aren't really content (but the opposite can also be true if your ids/classes are intended to convey meaning, e.g., color changes for success/error).
* I briefly looked at whether we should persist the normalized HTML, but decided against it:
  * we're normalizing the current HTML on page load anyway, so it's a bit clearer what's happening in the code
  * if we run into future normalization issues then the persisted HTML will be outdated again
  * there is be a 0.00001% chance that the original HTML might be necessary for some reason (though probably YAGNI)