### PR TITLE
Add ability to add intro message to MediaWiki:ManageApprovers page

### DIFF
--- a/src/EntryPoints/Specials/SpecialManageApprovers.php
+++ b/src/EntryPoints/Specials/SpecialManageApprovers.php
@@ -2,6 +2,7 @@
 
 namespace ProfessionalWiki\PageApprovals\EntryPoints\Specials;
 
+use MediaWiki\Html\Html;
 use MediaWiki\Request\WebRequest;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\User\UserFactory;
@@ -83,6 +84,16 @@ class SpecialManageApprovers extends SpecialPage {
 	private function renderHtml( array $approversCategories ): void {
 		$template = file_get_contents( __DIR__ . '/../../../templates/ManageApprovers.mustache' );
 		$compiledTemplate = LightnCandy::compile( $template, [ 'flags' => LightnCandy::FLAG_MUSTACHE ] );
+
+		if ( $this->msg( 'ext-pageapprovals-manage-intro' )->exists() ) {
+			$this->getOutput()->addHTML(
+				Html::rawElement( 'p',
+					[ 'id' => 'ext-pageapprovals-manage-intro' ],
+					$this->msg( 'ext-pageapprovals-manage-intro' )->parse()
+				)
+			);
+		}
+
 		$this->getOutput()->addHTML(
 			LightnCandy::prepare( $compiledTemplate )(
 				[ 'approvers' => $this->approversToViewModel( $approversCategories ) ]


### PR DESCRIPTION
Manually verified

Same idea as https://github.com/ProfessionalWiki/Rules/pull/64

This partially solves https://github.com/ProfessionalWiki/PageApprovals/issues/140. You can manually achieve the desired behavior and customize it as you wish on your wiki. An automated default link to Rules might still be useful, but this PR already gets at most of the value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an introductory paragraph to the Manage Approvers page, providing additional context or instructions at the top of the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->