### PR TITLE
WIP Retrieve HTML consistently

### DIFF
--- a/src/EntryPoints/PageApprovalsHooks.php
+++ b/src/EntryPoints/PageApprovalsHooks.php
@@ -22,7 +22,7 @@ class PageApprovalsHooks {
 		if ( self::isApprovablePage( $out ) ) {
 			PageApprovals::getInstance()->newEvaluateApprovalStateAction()->evaluate(
 				pageId: $out->getWikiPage()->getId(),
-				currentPageHtml: $parserOutput->getRawText(),
+				currentPageHtml: PageApprovals::getInstance()->getPageHtmlRetriever()->getPageHtml( $out->getWikiPage()->getId() ),
 			);
 		}
 	}


### PR DESCRIPTION
Debug for #144 

This does not solve the issue and the bug still happens with the change in this PR.

The change here is to retrieve the HTML in the same way, using our own HTML retriever service both on page load and on approval:
https://github.com/ProfessionalWiki/PageApprovals/blob/7b9f58636f782b8f7a3de6b89f4a26f9446b3197/src/EntryPoints/REST/ApprovePageApi.php#L54

I believe this points to "something else" happening or not happening on an actual page load versus our API call.