### PR TITLE
Set page in request context when approving

### DIFF
--- a/src/EntryPoints/REST/ApprovePageApi.php
+++ b/src/EntryPoints/REST/ApprovePageApi.php
@@ -31,7 +31,8 @@ class ApprovePageApi extends SimpleHandler {
 		private WikiPageFactory $wikiPageFactory,
 		private RevisionLookup $revisionLookup,
 		private UserIdentityLookup $userIdentityLookup,
-		private Language $language
+		private Language $language,
+		private RequestContext $requestContext
 	) {
 	}
 
@@ -53,7 +54,7 @@ class ApprovePageApi extends SimpleHandler {
 		$this->approvalLog->approvePage( $page->getId(), $this->getAuthority()->getUser()->getId() );
 
 		// Some extensions, like DisplayTitle, expect the current page to be in the request context.
-		RequestContext::getMain()->setTitle( $page->getTitle() );
+		$this->requestContext->setTitle( $page->getTitle() );
 		$html = $this->pageHtmlRetriever->getPageHtml( $page->getId() );
 		if ( $html !== null ) {
 			$this->htmlRepository->saveApprovedHtml( $page->getId(), $html );

--- a/src/EntryPoints/REST/ApprovePageApi.php
+++ b/src/EntryPoints/REST/ApprovePageApi.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\PageApprovals\EntryPoints\REST;
 
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Language\Language;
 use MediaWiki\Message\Message;
 use MediaWiki\Page\WikiPageFactory;
@@ -51,6 +52,8 @@ class ApprovePageApi extends SimpleHandler {
 
 		$this->approvalLog->approvePage( $page->getId(), $this->getAuthority()->getUser()->getId() );
 
+		// Some extensions, like DisplayTitle, expect the current page to be in the request context.
+		RequestContext::getMain()->setTitle( $page->getTitle() );
 		$html = $this->pageHtmlRetriever->getPageHtml( $page->getId() );
 		if ( $html !== null ) {
 			$this->htmlRepository->saveApprovedHtml( $page->getId(), $html );

--- a/src/PageApprovals.php
+++ b/src/PageApprovals.php
@@ -44,7 +44,8 @@ class PageApprovals {
 			MediaWikiServices::getInstance()->getWikiPageFactory(),
 			MediaWikiServices::getInstance()->getRevisionLookup(),
 			MediaWikiServices::getInstance()->getUserIdentityLookup(),
-			RequestContext::getMain()->getLanguage()
+			RequestContext::getMain()->getLanguage(),
+			RequestContext::getMain()
 		);
 	}
 

--- a/tests/EntryPoints/REST/ApprovePageApiTest.php
+++ b/tests/EntryPoints/REST/ApprovePageApiTest.php
@@ -28,6 +28,7 @@ class ApprovePageApiTest extends PageApprovalsIntegrationTest {
 	private InMemoryApprovalLog $approvalLog;
 	private HtmlRepository $htmlRepository;
 	private Language $language;
+	private RequestContext $requestContext;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -35,6 +36,7 @@ class ApprovePageApiTest extends PageApprovalsIntegrationTest {
 		$this->approvalLog = new InMemoryApprovalLog();
 		$this->htmlRepository = new InMemoryHtmlRepository();
 		$this->language = RequestContext::getMain()->getLanguage();
+		$this->requestContext = RequestContext::getMain();
 	}
 
 	public function testApprovePageHappyPath(): void {
@@ -68,7 +70,8 @@ class ApprovePageApiTest extends PageApprovalsIntegrationTest {
 			$this->getServiceContainer()->getWikiPageFactory(),
 			$this->getServiceContainer()->getRevisionLookup(),
 			$this->getServiceContainer()->getUserIdentityLookup(),
-			$this->language
+			$this->language,
+			$this->requestContext
 		);
 	}
 
@@ -106,7 +109,8 @@ class ApprovePageApiTest extends PageApprovalsIntegrationTest {
 			$this->getServiceContainer()->getWikiPageFactory(),
 			$this->getServiceContainer()->getRevisionLookup(),
 			$this->getServiceContainer()->getUserIdentityLookup(),
-			$this->language
+			$this->language,
+			$this->requestContext
 		);
 	}
 
@@ -176,6 +180,20 @@ EOT
 		);
 
 		$this->assertSame( 409, $response->getStatusCode() );
+	}
+
+	public function testRequestContextIsUpdatedWithPageToBeApproved(): void {
+		$page = $this->createPageWithCategories();
+
+		$this->executeHandler(
+			$this->newApprovePageApi(),
+			$this->createValidRequestData( $page->getRevisionRecord()->getId() ),
+		);
+
+		$this->assertSame(
+			$page->getTitle()->getText(),
+			$this->requestContext->getTitle()->getText()
+		);
 	}
 
 }


### PR DESCRIPTION
For #144 

DisplayTitle's link rewrite expects the request context to have the current page:
https://github.com/wikimedia/mediawiki-extensions-DisplayTitle/blob/b1a67a7c0db8f2cb24f9b74282e753c766a7efb2/includes/DisplayTitleHooks.php#L131-L141

Which is missing when the approve API runs. This PR sets the page into the current request context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the current page context/title is set immediately after approving a page so approved content and related metadata render correctly.
  * Improves compatibility with extensions and features that rely on the current page context (e.g., custom title display).

* **Tests**
  * Added tests to verify the request context is updated when a page is approved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->